### PR TITLE
Load starter directly into webcontainer to optimise input prompt usage

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -408,6 +408,9 @@ export const ChatImpl = memo(
         return null;
       });
 
+      // wait for 1.5 second to let the terminal shell be ready
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
       if (starterTemplateMessages) {
         setMessages([
           ...starterTemplateMessages,
@@ -428,6 +431,7 @@ export const ChatImpl = memo(
             experimental_attachments: createExperimentalAttachments(dataList, files),
           },
         ]);
+
         reload({
           body: {
             conversationId: chatId.get(),

--- a/app/lib/starter-instructions.prompt.ts
+++ b/app/lib/starter-instructions.prompt.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import { logger } from '~/utils/logger';
-import type { RepoFile } from '~/utils/selectStarterTemplate';
+import { getEncoding } from 'istextorbinary';
+import type { FileMap } from '~/lib/.server/llm/constants';
 
 const DIRECTORIES_TO_SKIP = ['.git', 'node_modules', 'build', '.idea', '.vscode', '.cache', 'analytics-dashboard'];
 const FILES_TO_SKIP = [
@@ -15,9 +16,9 @@ const FILES_TO_SKIP = [
 
 export const STARTER_DIRECTORY = process.env.STARTER_PATH!;
 
-export function readDirectory(dirPath: string, basePath: string = ''): any[] {
+export function readDirectory(dirPath: string, basePath: string = ''): FileMap {
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
-  const files: any[] = [];
+  let fileMap: FileMap = {};
   const sharedFiles = getSharedFiles();
 
   for (const entry of entries) {
@@ -29,7 +30,10 @@ export function readDirectory(dirPath: string, basePath: string = ''): any[] {
         continue;
       }
 
-      files.push(...readDirectory(fullPath, relativePath));
+      fileMap[relativePath] = { type: 'folder' };
+
+      const subDirMap = readDirectory(fullPath, relativePath);
+      fileMap = { ...fileMap, ...subDirMap };
     } else {
       if (FILES_TO_SKIP.includes(entry.name)) {
         continue;
@@ -41,20 +45,22 @@ export function readDirectory(dirPath: string, basePath: string = ''): any[] {
 
         // Extract all imports from shared files
         const sharedImports = new Set<string>();
-        sharedFiles.forEach((file) => {
-          const importMatches = file.content.match(/from ['"]([^'"]+)['"]/g) || [];
-          importMatches.forEach((match) => {
-            const importPath = match.match(/from ['"]([^'"]+)['"]/)?.[1];
+        Object.values(sharedFiles).forEach((file) => {
+          if (file?.type === 'file') {
+            const importMatches = file.content.match(/from ['"]([^'"]+)['"]/g) || [];
+            importMatches.forEach((match) => {
+              const importPath = match.match(/from ['"]([^'"]+)['"]/)?.[1];
 
-            if (importPath && !importPath.startsWith('.') && !importPath.startsWith('@/')) {
-              // Extract the package name from the import
-              const packageName = importPath.split('/')[0];
+              if (importPath && !importPath.startsWith('.') && !importPath.startsWith('@/')) {
+                // Extract the package name from the import
+                const packageName = importPath.split('/')[0];
 
-              if (packageName) {
-                sharedImports.add(packageName);
+                if (packageName) {
+                  sharedImports.add(packageName);
+                }
               }
-            }
-          });
+            });
+          }
         });
 
         // Add missing dependencies
@@ -62,7 +68,6 @@ export function readDirectory(dirPath: string, basePath: string = ''): any[] {
         const rootPackageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
         sharedImports.forEach((pkg) => {
           if (!dependencies[pkg]) {
-            // Read the version from package.json
             dependencies[pkg] =
               rootPackageJson.dependencies?.[pkg] || rootPackageJson.devDependencies?.[pkg] || 'latest';
             hasChanges = true;
@@ -76,20 +81,26 @@ export function readDirectory(dirPath: string, basePath: string = ''): any[] {
         }
       }
 
-      files.push({
-        name: entry.name,
-        path: relativePath,
-        content: fs.readFileSync(fullPath, 'utf8'),
-      });
+      const buffer = fs.readFileSync(fullPath);
+      const encoding = getEncoding(buffer);
+      const isBinary = encoding === 'binary';
+      fileMap[relativePath] = {
+        type: 'file',
+        content: isBinary ? '' : buffer.toString('utf8'),
+        isBinary,
+      };
     }
   }
 
-  return [...files, ...sharedFiles];
+  // Merge sharedFiles into fileMap
+  fileMap = { ...fileMap, ...sharedFiles };
+
+  return fileMap;
 }
 
-function getSharedFiles(): RepoFile[] {
+function getSharedFiles(): FileMap {
   const sharedDir = path.join(process.cwd(), 'shared/src');
-  const files: RepoFile[] = [];
+  const fileMap: FileMap = {};
 
   function processDirectory(dir: string, relativePath: string = '') {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -99,6 +110,7 @@ function getSharedFiles(): RepoFile[] {
       const relPath = path.join(relativePath, entry.name);
 
       if (entry.isDirectory()) {
+        fileMap[`app/lib/${relPath}`] = { type: 'folder' };
         processDirectory(fullPath, relPath);
       } else if (entry.isFile() && /\.(ts|tsx|js|jsx)$/.test(entry.name)) {
         const content = fs.readFileSync(fullPath, 'utf-8');
@@ -108,18 +120,20 @@ function getSharedFiles(): RepoFile[] {
           /from ['"]@liblab\/shared\/(.*?)['"]/g,
           (_, importPath) => `from '@/lib/${importPath}'`,
         );
-        files.push({
-          name: entry.name,
-          path: `app/lib/${relPath}`,
+        fileMap[`app/lib/${relPath}`] = {
+          type: 'file',
           content: modifiedContent,
-        });
+          isBinary: false,
+        };
       }
     }
   }
 
-  processDirectory(sharedDir);
+  if (fs.existsSync(sharedDir)) {
+    processDirectory(sharedDir);
+  }
 
-  return files;
+  return fileMap;
 }
 
 let starterInstructionsPrompt: string | null;

--- a/app/lib/starter-instructions.prompt.ts
+++ b/app/lib/starter-instructions.prompt.ts
@@ -74,10 +74,14 @@ export function readDirectory(dirPath: string, basePath: string = ''): FileMap {
           }
         });
 
-        // Update package.json if there were changes
         if (hasChanges) {
           packageJson.dependencies = dependencies;
-          fs.writeFileSync(fullPath, JSON.stringify(packageJson, null, 2));
+          fileMap[relativePath] = {
+            type: 'file',
+            content: JSON.stringify(packageJson, null, 2),
+            isBinary: false,
+          };
+          continue; // Skip the rest of the file handling for this file
         }
       }
 

--- a/app/lib/webcontainer/load-file-map.ts
+++ b/app/lib/webcontainer/load-file-map.ts
@@ -1,0 +1,39 @@
+import type { FileMap } from '~/lib/stores/files';
+import { injectEnvVariable } from '~/utils/envUtils';
+import { webcontainer } from '~/lib/webcontainer/index';
+
+/**
+ * Loads a file map into the web container.
+ * @param fileMap - The file map to load.
+ */
+export const loadFileMapIntoContainer = async (fileMap: FileMap): Promise<void> => {
+  const webContainer = await webcontainer;
+
+  for (const [key, value] of Object.entries(fileMap)) {
+    if (value?.type !== 'folder') {
+      continue;
+    }
+
+    const folderName = key.startsWith(webContainer.workdir) ? key.replace(webContainer.workdir, '') : key;
+    await webContainer.fs.mkdir(folderName, { recursive: true });
+  }
+
+  for (const [key, value] of Object.entries(fileMap)) {
+    if (value?.type !== 'file') {
+      continue;
+    }
+
+    if (key.endsWith('.env') && import.meta.env.VITE_ENV_NAME === 'local') {
+      const tunnelForwardingUrl = import.meta.env.VITE_TUNNEL_FORWARDING_URL;
+      value.content = injectEnvVariable(
+        value.content,
+        'VITE_API_BASE_URL',
+        tunnelForwardingUrl ? tunnelForwardingUrl : undefined,
+      );
+    }
+
+    const fileName = key.startsWith(webContainer.workdir) ? key.replace(webContainer.workdir, '') : key;
+
+    await webContainer.fs.writeFile(fileName, value.content, { encoding: value.isBinary ? undefined : 'utf8' });
+  }
+};

--- a/app/routes/api.starter-template.ts
+++ b/app/routes/api.starter-template.ts
@@ -1,18 +1,18 @@
 import fs from 'fs';
-import { json } from '@remix-run/cloudflare';
 import { readDirectory, STARTER_DIRECTORY } from '~/lib/starter-instructions.prompt';
+import type { FileMap } from '~/lib/.server/llm/constants';
 
 export const loader = async () => {
   try {
     if (!fs.existsSync(STARTER_DIRECTORY)) {
-      return json({ error: 'Starter template directory not found' }, { status: 404 });
+      return Response.json({ error: 'Starter template directory not found' }, { status: 404 });
     }
 
-    const files = readDirectory(STARTER_DIRECTORY);
+    const files: FileMap = readDirectory(STARTER_DIRECTORY);
 
-    return json({ files });
+    return Response.json({ files });
   } catch (error) {
     console.error('Error reading starter template:', error);
-    return json({ error: 'Failed to read starter template' }, { status: 500 });
+    return Response.json({ error: 'Failed to read starter template' }, { status: 500 });
   }
 };

--- a/app/utils/selectStarterTemplate.ts
+++ b/app/utils/selectStarterTemplate.ts
@@ -1,48 +1,50 @@
 import { MessageRole } from '~/utils/constants';
 import { type Message } from 'ai';
+import type { FileMap } from '~/lib/stores/files';
+import { loadFileMapIntoContainer } from '~/lib/webcontainer/load-file-map';
 
 export type RepoFile = { name: string; path: string; content: string };
 
 interface StarterTemplateResponse {
-  files?: RepoFile[];
+  files?: FileMap;
   error?: string;
 }
 
-function writeSensitiveDataToEnvFile(files: RepoFile[], databaseUrl: string): RepoFile {
-  const envFile = files.find((x) => x.path.includes('.env'));
+function writeSensitiveDataToEnvFile(files: FileMap, databaseUrl: string): FileMap {
+  const envPath = Object.keys(files).find((key) => key.includes('.env')) || '.env';
   const encodedDatabaseUrl = encodeURIComponent(databaseUrl);
-
   const encryptionKey = process.env.ENCRYPTION_KEY;
 
   if (!encryptionKey) {
     throw new Error('ENCRYPTION_KEY environment variable is not set');
   }
 
-  if (envFile) {
+  let content = '';
+
+  if (files[envPath] && files[envPath]?.type === 'file') {
     // Append database URL to existing env file content
-    const existingContent = envFile.content.trim();
-    envFile.content = existingContent
+    const existingContent = files[envPath]?.content.trim() || '';
+    content = existingContent
       ? `${existingContent}\nDATABASE_URL='${encodedDatabaseUrl}'`
       : `DATABASE_URL='${encodedDatabaseUrl}'`;
-
-    envFile.content += '\n'; // Ensure it ends with a newline
-    envFile.content += `ENCRYPTION_KEY='${encryptionKey}'\n`;
-
-    return envFile;
+    content += '\n'; // Ensure it ends with a newline
+    content += `ENCRYPTION_KEY='${encryptionKey}'\n`;
+  } else {
+    content = `DATABASE_URL='${encodedDatabaseUrl}'\n`;
+    content += `ENCRYPTION_KEY='${encryptionKey}'\n`;
   }
 
-  let content = `DATABASE_URL='${encodedDatabaseUrl}'\n`;
-  content += `ENCRYPTION_KEY='${encryptionKey}'\n`;
-
-  // Create new env file if none exists
   return {
-    name: '.env',
-    path: '.env',
-    content,
+    ...files,
+    [envPath]: {
+      type: 'file',
+      content,
+      isBinary: false,
+    },
   };
 }
 
-const getStarterTemplateFiles = async (): Promise<RepoFile[]> => {
+const getStarterTemplateFiles = async (): Promise<FileMap> => {
   try {
     const response = await fetch('/api/starter-template');
 
@@ -69,8 +71,12 @@ const getStarterTemplateFiles = async (): Promise<RepoFile[]> => {
 
 export async function getStarterTemplateMessages(title: string, databaseUrl: string): Promise<Message[]> {
   const starterFiles = await getStarterTemplateFiles();
-  const envFile = writeSensitiveDataToEnvFile(starterFiles, databaseUrl);
-  const allFiles = [...starterFiles, envFile];
+  const updatedFiles = writeSensitiveDataToEnvFile(starterFiles, databaseUrl);
+
+  await loadFileMapIntoContainer(updatedFiles);
+
+  // wait for 1 second
+  await new Promise((resolve) => setTimeout(resolve, 1000));
 
   return [
     {
@@ -82,24 +88,20 @@ export async function getStarterTemplateMessages(title: string, databaseUrl: str
     {
       id: `2-${new Date().getTime()}`,
       role: MessageRole.Assistant,
-      content: getStarterTemplateArtifact(title, allFiles),
+      content: getStarterTemplateArtifact(title, updatedFiles),
       annotations: ['hidden'],
     },
   ];
 }
 
-function getStarterTemplateArtifact(title: string, filesToImport: RepoFile[]): string {
-  return `
-<liblabArtifact id="imported-files" title="${title}" type="bundled">
-${filesToImport
-  .map(
-    (file) =>
-      `<liblabAction type="file" filePath="${file.path}">
-${file.content}
-</liblabAction>`,
-  )
-  .join('\n')}
-<liblabAction type="shell">pnpm install</liblabAction>
-</liblabArtifact>
-`;
+function getStarterTemplateArtifact(title: string, files: FileMap): string {
+  const fileList = Object.entries(files)
+    .filter(([, value]) => value?.type === 'file')
+    .map(([path]) => `- ${path}`)
+    .join('\n');
+
+  return `I imported the following files:\n${fileList}\n
+<liblabArtifact id="imported-files" title="${title}" type="bundled">\n
+<liblabAction type="shell">pnpm install</liblabAction>\n
+</liblabArtifact>`;
 }

--- a/app/utils/selectStarterTemplate.ts
+++ b/app/utils/selectStarterTemplate.ts
@@ -75,9 +75,6 @@ export async function getStarterTemplateMessages(title: string, databaseUrl: str
 
   await loadFileMapIntoContainer(updatedFiles);
 
-  // wait for 1 second
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
   return [
     {
       id: `1-${new Date().getTime()}`,


### PR DESCRIPTION
## 📋 Pull Request Summary

Fixes an issue with breaking input context window. 
Previously, starter was imported through the assistant message, meaning all the files from starter repository were sent to the LLM and later processed by message parser. 

This PR changes how starter project is loaded - instead of sending it as a liblab aftifact in assistant message, we load the file map directly into the webcontainer file system, sending to the LLM only the list of files. The only concern I had with this approach is that LLM will have less context for making changes, but after testing it, it did the same job as before.

Changes include:
- Changing the response type of endpoint for getting starter template (`GET api/starter-template`) to return `FileMap` type instead of `RepoFile`.
- Add function for loading files into the webcontainer directly (file `load-file-map.ts`)
- Change the client-side logic that sets initial messages to call this function

This change will significantly reduce input tokens amount. From 100k+ tokens to ~10-20k tokens.

Other unrelated fix:
- Do not write updated package.json on the file system if there are new dependencies detected in the data accessor files.
