### PR TITLE
Fix chat title too long and still being shown after the log out

### DIFF
--- a/app/components/auth/LogoutButton.tsx
+++ b/app/components/auth/LogoutButton.tsx
@@ -3,6 +3,7 @@ import { signOut, useSession } from '~/auth/auth-client';
 import { useNavigate } from '@remix-run/react';
 import { ProfilePicture } from './ProfilePicture';
 import { useAuthProvidersPlugin } from '~/lib/hooks/plugins/useAuthProvidersPlugin';
+import { chatStore } from '~/lib/stores/chat';
 
 export function LogoutButton() {
   const [isOpen, setIsOpen] = useState(false);
@@ -59,8 +60,9 @@ export function LogoutButton() {
           {!anonymousProvider && (
             <div className="py-1">
               <button
-                onClick={() => {
-                  handleLogout();
+                onClick={async () => {
+                  await handleLogout();
+                  chatStore.setKey('started', false);
                   setIsOpen(false);
                 }}
                 className="w-full text-left px-4 py-2 text-liblab-elements-textPrimary hover:bg-liblab-elements-item-backgroundAccent hover:text-liblab-elements-item-contentAccent transition-colors flex items-center text-sm group"

--- a/app/lib/persistence/useConversationHistory.ts
+++ b/app/lib/persistence/useConversationHistory.ts
@@ -91,6 +91,7 @@ export function useConversationHistory() {
     storeConversationHistory: async (
       lastMessageId: string,
       onSnapshotCreated?: (snapshotId: string, messageId: string) => void,
+      artifactTitle?: string,
     ) => {
       const conversationId = chatId.get();
 
@@ -106,11 +107,15 @@ export function useConversationHistory() {
 
       const firstArtifact = workbenchStore.firstArtifact;
 
-      if (!description.get() && firstArtifact?.title) {
-        await updateConversation(conversationId, {
-          description: firstArtifact.title,
-        });
-        description.set(firstArtifact.title);
+      if (!description.get()) {
+        const descriptionToUpdate = artifactTitle || firstArtifact?.title;
+
+        if (descriptionToUpdate) {
+          await updateConversation(conversationId, {
+            description: descriptionToUpdate,
+          });
+          description.set(descriptionToUpdate);
+        }
       }
 
       await pushToRemote();

--- a/app/utils/artifactMapper.ts
+++ b/app/utils/artifactMapper.ts
@@ -27,3 +27,10 @@ export const mapRemoteChangesToArtifact = (changes: RemoteChanges): Message | un
     content: artifactContent,
   };
 };
+
+export const extractArtifactTitleFromMessageContent = (messageContent: string) => {
+  const artifactRegex = /<liblabArtifact[^>]*title="([^"]*)"[^>]*>/;
+  const match = messageContent.match(artifactRegex);
+
+  return match ? match[1] : undefined;
+};


### PR DESCRIPTION
- take the title of the generated artifact instead of the title of the first artifact which is actually a user prompt 
- fix chat title being shown after the logout