### PR TITLE
Increase number of files in context buffer

### DIFF
--- a/app/lib/.server/llm/select-context.ts
+++ b/app/lib/.server/llm/select-context.ts
@@ -136,7 +136,7 @@ export async function selectContext(props: {
         * context buffer should not include any file that is not in the list of files above.
         * context buffer is extremely expensive, so only include files that are absolutely necessary.
         * If no changes are needed, you can leave the response empty updateContextBuffer tag.
-        * Only 5 files can be placed in the context buffer at a time.
+        * Only 10 files can be placed in the context buffer at a time.
         * if the buffer is full, you need to exclude files that is not needed and include files that are relevant.
 
         `,


### PR DESCRIPTION
Since we're not importing starter template through the assistant message, I think this change will improve the quality of LLM responses. 

1. We have more room in input prompt token count window 
2. We have small components that are important for the LLM to understand, and adding additional 5 files to the context buffer could really help
3. Previously LLM had the knowledge of each and every file in our codebase, and it was too much, but having only 5 files can be too little