### PR TITLE
Explicitly specify max tokens for code generation LLM request

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -1,5 +1,4 @@
-// see https://docs.anthropic.com/en/docs/about-claude/models
-export const MAX_TOKENS = 8000;
+export const DEFAULT_MAX_OUTPUT_TOKENS = 20000;
 
 // limits the number of model responses that can be returned in a single request
 export const MAX_RESPONSE_SEGMENTS = 2;
@@ -36,3 +35,38 @@ export const IGNORE_PATTERNS = [
   '**/*lock.json',
   '**/*lock.yml',
 ];
+
+/**
+ * Get the maximum number of tokens for a given provider and model.
+ * @param provider - The provider of the model.
+ * @param model - The model to get the maximum number of tokens for.
+ * @returns The maximum number of tokens for the given provider and model.
+ */
+export const getMaxTokens = (provider: string, model: string): number => {
+  const providerMap = MAX_OUTPUT_TOKENS_MAP[provider];
+
+  if (providerMap) {
+    for (const modelPrefix in providerMap) {
+      // To avoid specifying the exact model name, we use the prefix to match the model name.
+      // e.g. 'claude-3-5-sonnet' matches 'claude-3-5-sonnet-20240620' or 'claude-3-5-sonnet-latest'
+      if (model.startsWith(modelPrefix)) {
+        return providerMap[modelPrefix];
+      }
+    }
+  }
+
+  return DEFAULT_MAX_OUTPUT_TOKENS;
+};
+
+const MAX_OUTPUT_TOKENS_MAP: Record<string, Record<string, number>> = {
+  Anthropic: {
+    'claude-3-5-sonnet': 8192,
+    'claude-3-7-sonnet': 64000,
+    'claude-sonnet-4': 64000,
+    'claude-opus': 32000,
+  },
+  Google: {
+    'gemini-2.5-flash': 65000,
+    'gemini-2.5-pro': 65000,
+  },
+};

--- a/app/lib/.server/llm/get-llm.ts
+++ b/app/lib/.server/llm/get-llm.ts
@@ -1,8 +1,10 @@
 import type { LanguageModelV1 } from 'ai';
 import { LLMManager } from '~/lib/modules/llm/manager';
+import { getMaxTokens } from '~/lib/.server/llm/constants';
 
-type Llm = {
+export type Llm = {
   instance: LanguageModelV1;
+  maxOutputTokens: number;
 };
 
 export async function getLlm(): Promise<Llm> {
@@ -15,5 +17,5 @@ export async function getLlm(): Promise<Llm> {
     serverEnv: process.env as any,
   });
 
-  return { instance };
+  return { instance, maxOutputTokens: getMaxTokens(provider.name, modelName) };
 }

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -116,7 +116,7 @@ ${props.summary}
 
   if (
     isFirstUserMessage(processedMessages) ||
-    (await shouldGenerateSqlQueries(lastUserMessage, llm.instance, existingQueries))
+    (await shouldGenerateSqlQueries(lastUserMessage, llm, existingQueries))
   ) {
     const userId = await requireUserId(request);
     const schema = await getDatabaseSchema(currentDataSourceId, userId);
@@ -125,7 +125,7 @@ ${props.summary}
     const connectionDetails = new URL(dataSource.connectionString);
     const type = connectionDetails.protocol.replace(':', '');
 
-    const sqlQueries = await generateSqlQueries(schema, lastUserMessage, llm.instance, type, existingQueries);
+    const sqlQueries = await generateSqlQueries(schema, lastUserMessage, llm, type, existingQueries);
 
     if (sqlQueries?.length) {
       logger.debug(`Adding SQL queries as the hidden user message`);
@@ -143,6 +143,7 @@ ${props.summary}
   return _streamText({
     model: llm.instance,
     system: systemPrompt,
+    maxTokens: llm.maxOutputTokens,
     messages: convertToCoreMessages(processedMessages as any),
     ...options,
   });

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -20,25 +20,7 @@ export async function action(args: ActionFunctionArgs) {
 
 const logger = createScopedLogger('api.chat');
 
-function parseCookies(cookieHeader: string): Record<string, string> {
-  const cookies: Record<string, string> = {};
-
-  const items = cookieHeader.split(';').map((cookie) => cookie.trim());
-
-  items.forEach((item) => {
-    const [name, ...rest] = item.split('=');
-
-    if (name && rest) {
-      const decodedName = decodeURIComponent(name.trim());
-      const decodedValue = decodeURIComponent(rest.join('=').trim());
-      cookies[decodedName] = decodedValue;
-    }
-  });
-
-  return cookies;
-}
-
-async function chatAction({ context, request }: ActionFunctionArgs) {
+async function chatAction({ request }: ActionFunctionArgs) {
   const body = await request.json<{
     messages: Messages;
     files: any;
@@ -56,9 +38,6 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
       statusText: 'Bad Request',
     });
   }
-
-  const cookieHeader = request.headers.get('Cookie');
-  const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');
 
   const conversation = await conversationService.getConversation(conversationId);
 
@@ -112,9 +91,6 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
 
             summary = await createSummary({
               messages: [...messages],
-              env: context.cloudflare?.env,
-              apiKeys,
-              promptId,
               contextOptimization,
               onFinish(resp) {
                 if (resp.usage) {
@@ -158,10 +134,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
             logger.debug(`Messages count: ${messages.length}`);
             filteredFiles = await selectContext({
               messages: [...messages],
-              env: context.cloudflare?.env,
-              apiKeys,
               files,
-              promptId,
               contextOptimization,
               summary,
               onFinish(resp) {

--- a/app/routes/api.generate-query.ts
+++ b/app/routes/api.generate-query.ts
@@ -34,7 +34,7 @@ export const action: ActionFunction = async ({ request }) => {
     const connectionDetails = new URL(dataSource.connectionString);
     const type = connectionDetails.protocol.replace(':', '');
 
-    const queries = await generateSqlQueries(schema, prompt, llm.instance, type, existingQueries);
+    const queries = await generateSqlQueries(schema, prompt, llm, type, existingQueries);
 
     if (!queries || queries.length === 0) {
       return json({ error: 'Failed to generate SQL query' }, { status: 500 });


### PR DESCRIPTION
This limit was previously removed with https://github.com/liblaber/ai/pull/68, but without explicit value request gets cut off automatically at 4056 tokens by ai-sdk.
In this PR I am introducing simple logic for getting the maximum output tokens number. By default, 20000 value will be used if model name does not get matched in the map.