### PR TITLE
Upgrade Zod to v4

### DIFF
--- a/app/env/client.ts
+++ b/app/env/client.ts
@@ -9,11 +9,7 @@ export const env = createEnv({
     NEXT_PUBLIC_LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
     NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
     NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
-    NEXT_PUBLIC_DISABLE_TELEMETRY: z
-      .preprocess((value) => {
-        return typeof value === 'string' ? JSON.parse(value) : value;
-      }, z.boolean())
-      .default(false),
+    NEXT_PUBLIC_DISABLE_TELEMETRY: z.stringbool().default(false),
     NEXT_PUBLIC_GITHUB_ACCESS_TOKEN: z.string().optional(),
   },
   runtimeEnv: {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "unist-util-visit": "^5.0.0",
     "vite-plugin-node-polyfills": "^0.22.0",
     "wrangler": "^4.14.1",
-    "zod": "^3.24.1",
+    "zod": "^4.0.14",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,28 +17,28 @@ importers:
     dependencies:
       '@ai-sdk/amazon-bedrock':
         specifier: 1.0.6
-        version: 1.0.6(zod@3.25.36)
+        version: 1.0.6(zod@4.0.14)
       '@ai-sdk/anthropic':
         specifier: ^0.0.39
-        version: 0.0.39(zod@3.25.36)
+        version: 0.0.39(zod@4.0.14)
       '@ai-sdk/cohere':
         specifier: ^1.0.3
-        version: 1.2.10(zod@3.25.36)
+        version: 1.2.10(zod@4.0.14)
       '@ai-sdk/deepseek':
         specifier: ^0.1.3
-        version: 0.1.17(zod@3.25.36)
+        version: 0.1.17(zod@4.0.14)
       '@ai-sdk/google':
         specifier: ^0.0.52
-        version: 0.0.52(zod@3.25.36)
+        version: 0.0.52(zod@4.0.14)
       '@ai-sdk/mistral':
         specifier: ^0.0.43
-        version: 0.0.43(zod@3.25.36)
+        version: 0.0.43(zod@4.0.14)
       '@ai-sdk/openai':
         specifier: ^1.1.2
-        version: 1.3.22(zod@3.25.36)
+        version: 1.3.22(zod@4.0.14)
       '@ai-sdk/react':
         specifier: ^1.2.12
-        version: 1.2.12(react@18.3.1)(zod@3.25.36)
+        version: 1.2.12(react@18.3.1)(zod@4.0.14)
       '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0(encoding@0.1.13)
@@ -113,7 +113,7 @@ importers:
         version: 21.1.1
       '@openrouter/ai-sdk-provider':
         specifier: ^0.0.5
-        version: 0.0.5(zod@3.25.36)
+        version: 0.0.5(zod@4.0.14)
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
@@ -161,7 +161,7 @@ importers:
         version: 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
-        version: 0.13.8(typescript@5.8.3)(zod@3.25.36)
+        version: 0.13.8(typescript@5.8.3)(zod@4.0.14)
       '@tanstack/react-virtual':
         specifier: ^3.13.0
         version: 3.13.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -188,7 +188,7 @@ importers:
         version: 0.5.16
       ai:
         specifier: ^4.1.2
-        version: 4.3.16(react@18.3.1)(zod@3.25.36)
+        version: 4.3.16(react@18.3.1)(zod@4.0.14)
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -266,7 +266,7 @@ importers:
         version: 2.2.0(next@15.3.5(@babel/core@7.27.3)(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2))
       ollama-ai-provider:
         specifier: ^0.15.2
-        version: 0.15.2(zod@3.25.36)
+        version: 0.15.2(zod@4.0.14)
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
@@ -355,8 +355,8 @@ importers:
         specifier: ^4.14.1
         version: 4.18.0(@cloudflare/workers-types@4.20250529.0)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.36
+        specifier: ^4.0.14
+        version: 4.0.14
       zustand:
         specifier: ^5.0.3
         version: 5.0.5(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -915,8 +915,8 @@ packages:
     resolution: {integrity: sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.27.6':
-    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -4371,8 +4371,8 @@ packages:
   caniuse-lite@1.0.30001720:
     resolution: {integrity: sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==}
 
-  caniuse-lite@1.0.30001727:
-    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+  caniuse-lite@1.0.30001731:
+    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
 
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
@@ -5056,8 +5056,8 @@ packages:
   electron-to-chromium@1.5.161:
     resolution: {integrity: sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==}
 
-  electron-to-chromium@1.5.183:
-    resolution: {integrity: sha512-vCrDBYjQCAEefWGjlK3EpoSKfKbT10pR4XXPdn65q7snuNOZnthoVpBfZPykmDapOKfoD+MMIPG8ZjKyyc9oHA==}
+  electron-to-chromium@1.5.193:
+    resolution: {integrity: sha512-eePuBZXM9OVCwfYUhd2OzESeNGnWmLyeu0XAEjf7xjijNjHFdeJSzuRUGN4ueT2tEYo5YqjHramKEFxz67p3XA==}
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
@@ -9707,8 +9707,11 @@ packages:
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
-  zod@3.25.36:
-    resolution: {integrity: sha512-eRFS3i8T0IrpGdL8HQyqFAugGOn7jOjyGgGdtv5NY4Wkhi7lJDk732bNZ609YMIGFbLoaj6J69O1Mura23gfIw==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.0.14:
+    resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
 
   zustand@5.0.5:
     resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
@@ -9735,110 +9738,110 @@ snapshots:
 
   '@adobe/css-tools@4.4.3': {}
 
-  '@ai-sdk/amazon-bedrock@1.0.6(zod@3.25.36)':
+  '@ai-sdk/amazon-bedrock@1.0.6(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.0.3
-      '@ai-sdk/provider-utils': 2.0.5(zod@3.25.36)
+      '@ai-sdk/provider-utils': 2.0.5(zod@4.0.14)
       '@aws-sdk/client-bedrock-runtime': 3.817.0
-      zod: 3.25.36
+      zod: 4.0.14
     transitivePeerDependencies:
       - aws-crt
 
-  '@ai-sdk/anthropic@0.0.39(zod@3.25.36)':
+  '@ai-sdk/anthropic@0.0.39(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.17
-      '@ai-sdk/provider-utils': 1.0.9(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 1.0.9(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/cohere@1.2.10(zod@3.25.36)':
+  '@ai-sdk/cohere@1.2.10(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/deepseek@0.1.17(zod@3.25.36)':
+  '@ai-sdk/deepseek@0.1.17(zod@4.0.14)':
     dependencies:
-      '@ai-sdk/openai-compatible': 0.1.17(zod@3.25.36)
+      '@ai-sdk/openai-compatible': 0.1.17(zod@4.0.14)
       '@ai-sdk/provider': 1.0.12
-      '@ai-sdk/provider-utils': 2.1.15(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 2.1.15(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/google@0.0.52(zod@3.25.36)':
+  '@ai-sdk/google@0.0.52(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.24
-      '@ai-sdk/provider-utils': 1.0.20(zod@3.25.36)
+      '@ai-sdk/provider-utils': 1.0.20(zod@4.0.14)
       json-schema: 0.4.0
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/mistral@0.0.43(zod@3.25.36)':
+  '@ai-sdk/mistral@0.0.43(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.24
-      '@ai-sdk/provider-utils': 1.0.20(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 1.0.20(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/openai-compatible@0.1.17(zod@3.25.36)':
+  '@ai-sdk/openai-compatible@0.1.17(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.0.12
-      '@ai-sdk/provider-utils': 2.1.15(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 2.1.15(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/openai@1.3.22(zod@3.25.36)':
+  '@ai-sdk/openai@1.3.22(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.14)
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@1.0.2(zod@3.25.36)':
+  '@ai-sdk/provider-utils@1.0.2(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.12
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@1.0.20(zod@3.25.36)':
+  '@ai-sdk/provider-utils@1.0.20(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.24
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@1.0.9(zod@3.25.36)':
+  '@ai-sdk/provider-utils@1.0.9(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.17
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@2.0.5(zod@3.25.36)':
+  '@ai-sdk/provider-utils@2.0.5(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.0.3
       eventsource-parser: 3.0.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@2.1.15(zod@3.25.36)':
+  '@ai-sdk/provider-utils@2.1.15(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.0.12
       eventsource-parser: 3.0.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.36)':
+  '@ai-sdk/provider-utils@2.2.8(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.36
+      zod: 4.0.14
 
   '@ai-sdk/provider@0.0.12':
     dependencies:
@@ -9864,22 +9867,22 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.25.36)':
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.0.14)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.36)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.36)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.14)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.0.14)
       react: 18.3.1
       swr: 2.3.3(react@18.3.1)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@ai-sdk/ui-utils@1.2.11(zod@3.25.36)':
+  '@ai-sdk/ui-utils@1.2.11(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.36)
-      zod: 3.25.36
-      zod-to-json-schema: 3.24.5(zod@3.25.36)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.14)
+      zod: 4.0.14
+      zod-to-json-schema: 3.24.5(zod@4.0.14)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -10457,7 +10460,7 @@ snapshots:
 
   '@babel/runtime@7.27.3': {}
 
-  '@babel/runtime@7.27.6': {}
+  '@babel/runtime@7.28.2': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -11739,7 +11742,7 @@ snapshots:
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
       yargs: 17.7.2
-      zod: 3.25.36
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -11855,11 +11858,11 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
-  '@openrouter/ai-sdk-provider@0.0.5(zod@3.25.36)':
+  '@openrouter/ai-sdk-provider@0.0.5(zod@4.0.14)':
     dependencies:
       '@ai-sdk/provider': 0.0.12
-      '@ai-sdk/provider-utils': 1.0.2(zod@3.25.36)
-      zod: 3.25.36
+      '@ai-sdk/provider-utils': 1.0.2(zod@4.0.14)
+      zod: 4.0.14
 
   '@opentelemetry/api@1.8.0': {}
 
@@ -13004,17 +13007,17 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@t3-oss/env-core@0.13.8(typescript@5.8.3)(zod@3.25.36)':
+  '@t3-oss/env-core@0.13.8(typescript@5.8.3)(zod@4.0.14)':
     optionalDependencies:
       typescript: 5.8.3
-      zod: 3.25.36
+      zod: 4.0.14
 
-  '@t3-oss/env-nextjs@0.13.8(typescript@5.8.3)(zod@3.25.36)':
+  '@t3-oss/env-nextjs@0.13.8(typescript@5.8.3)(zod@4.0.14)':
     dependencies:
-      '@t3-oss/env-core': 0.13.8(typescript@5.8.3)(zod@3.25.36)
+      '@t3-oss/env-core': 0.13.8(typescript@5.8.3)(zod@4.0.14)
     optionalDependencies:
       typescript: 5.8.3
-      zod: 3.25.36
+      zod: 4.0.14
 
   '@tanstack/react-virtual@3.13.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -13027,7 +13030,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -13841,15 +13844,15 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@4.3.16(react@18.3.1)(zod@3.25.36):
+  ai@4.3.16(react@18.3.1)(zod@4.0.14):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.36)
-      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.25.36)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.36)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.0.14)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.0.14)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.0.14)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.25.36
+      zod: 4.0.14
     optionalDependencies:
       react: 18.3.1
 
@@ -14126,7 +14129,7 @@ snapshots:
       jose: 5.10.0
       kysely: 0.28.2
       nanostores: 0.11.4
-      zod: 3.25.36
+      zod: 3.25.76
 
   better-call@1.0.9:
     dependencies:
@@ -14269,8 +14272,8 @@ snapshots:
 
   browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001727
-      electron-to-chromium: 1.5.183
+      caniuse-lite: 1.0.30001731
+      electron-to-chromium: 1.5.193
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -14362,7 +14365,7 @@ snapshots:
 
   caniuse-lite@1.0.30001720: {}
 
-  caniuse-lite@1.0.30001727: {}
+  caniuse-lite@1.0.30001731: {}
 
   canvg@3.0.11:
     dependencies:
@@ -15050,7 +15053,7 @@ snapshots:
 
   electron-to-chromium@1.5.161: {}
 
-  electron-to-chromium@1.5.183: {}
+  electron-to-chromium@1.5.193: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -17810,13 +17813,13 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider@0.15.2(zod@3.25.36):
+  ollama-ai-provider@0.15.2(zod@4.0.14):
     dependencies:
       '@ai-sdk/provider': 0.0.24
-      '@ai-sdk/provider-utils': 1.0.20(zod@3.25.36)
+      '@ai-sdk/provider-utils': 1.0.20(zod@4.0.14)
       partial-json: 0.1.7
     optionalDependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
   omit.js@2.0.2: {}
 
@@ -20376,13 +20379,15 @@ snapshots:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
 
-  zod-to-json-schema@3.24.5(zod@3.25.36):
+  zod-to-json-schema@3.24.5(zod@4.0.14):
     dependencies:
-      zod: 3.25.36
+      zod: 4.0.14
 
   zod@3.22.3: {}
 
-  zod@3.25.36: {}
+  zod@3.25.76: {}
+
+  zod@4.0.14: {}
 
   zustand@5.0.5(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
This pull request focuses on upgrading the `zod` library to version 4.0.14 and updating related dependencies and configurations across the project. The changes include simplifying the schema definition for `NEXT_PUBLIC_DISABLE_TELEMETRY`, updating `package.json` and `pnpm-lock.yaml` to reflect the new `zod` version, and ensuring compatibility with other dependencies that rely on `zod`.

### Key Changes:

#### Schema Updates:
- Simplified the schema definition for `NEXT_PUBLIC_DISABLE_TELEMETRY` in `app/env/client.ts` by replacing a custom preprocessing logic with the new `z.stringbool()` method introduced in `zod` 4.x.

#### Dependency Upgrades:
- Upgraded `zod` from version `^3.24.1` to `^4.0.14` in `package.json`.