### PR TITLE
Fix table name quoting in getSchema method for SQLiteAccessor

### DIFF
--- a/shared/src/data-access/accessors/sqlite.ts
+++ b/shared/src/data-access/accessors/sqlite.ts
@@ -105,7 +105,9 @@ export class SQLiteAccessor implements BaseAccessor {
 
       // For each table, get its columns
       for (const table of tables) {
-        const columns: SQLiteColumn[] = this._db.pragma(`table_info("${table.table_name.replace(/"/g, '""')}")`) as SQLiteColumn[];
+        const columns: SQLiteColumn[] = this._db.pragma(
+          `table_info("${table.table_name.replace(/"/g, '""')}")`,
+        ) as SQLiteColumn[];
         result.push({
           tableName: table.table_name,
           columns: columns.map((col) => {

--- a/shared/src/data-access/accessors/sqlite.ts
+++ b/shared/src/data-access/accessors/sqlite.ts
@@ -105,7 +105,7 @@ export class SQLiteAccessor implements BaseAccessor {
 
       // For each table, get its columns
       for (const table of tables) {
-        const columns: SQLiteColumn[] = this._db.pragma(`table_info("${table.table_name}")`) as SQLiteColumn[];
+        const columns: SQLiteColumn[] = this._db.pragma(`table_info("${table.table_name.replace(/"/g, '""')}")`) as SQLiteColumn[];
         result.push({
           tableName: table.table_name,
           columns: columns.map((col) => {

--- a/shared/src/data-access/accessors/sqlite.ts
+++ b/shared/src/data-access/accessors/sqlite.ts
@@ -105,7 +105,7 @@ export class SQLiteAccessor implements BaseAccessor {
 
       // For each table, get its columns
       for (const table of tables) {
-        const columns: SQLiteColumn[] = this._db.pragma(`table_info(${table.table_name})`) as SQLiteColumn[];
+        const columns: SQLiteColumn[] = this._db.pragma(`table_info("${table.table_name}")`) as SQLiteColumn[];
         result.push({
           tableName: table.table_name,
           columns: columns.map((col) => {


### PR DESCRIPTION
Ensure proper quoting of table names in the getSchema method to prevent potential SQL errors.