### PR TITLE
Handle LLM provider auth errors gracefully

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -7,6 +7,8 @@ export const DATA_SOURCE_ID_REGEX = /\[DataSourceId: (.*?)\]\n\n/;
 export const FILES_REGEX = /\[Files: (.*?)\]\n\n/;
 export const PROJECT_SETUP_ANNOTATION = 'project-setup';
 export const FIX_ANNOTATION = 'fix';
+export const AI_SDK_INVALID_KEY_ERROR =
+  'TypeError: Cannot convert argument to a ByteString because the character at index';
 
 export enum MessageRole {
   User = 'user',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
   {
     rules: {
       '@blitz/catch-error-name': 'off',
+      '@blitz/lines-around-comment': 'off',
       '@typescript-eslint/no-this-alias': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',
       '@blitz/comment-syntax': 'off',


### PR DESCRIPTION
This PR handles failed LLM auth requests:
 - failed with 401 status cude
 - and the special case where an invalid API key containing special characters makes ai sdk throw unhandled error
 
 
<img width="1080" height="714" alt="image" src="https://github.com/user-attachments/assets/31eb2444-59c1-40f4-8490-d1cd86777530" />
