### PR TITLE
Add RBAC cache invalidation

### DIFF
--- a/app/api/roles/[roleId]/permissions/[permissionId]/route.ts
+++ b/app/api/roles/[roleId]/permissions/[permissionId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { deletePermission, getPermission } from '~/lib/services/permissionService';
 import { requireUserAbility } from '~/auth/session';
 import { PermissionAction, PermissionResource, Prisma } from '@prisma/client';
+import { invalidateUserAbilityCacheByRoleId } from '~/lib/casl/user-ability';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ permissionId: string }> }) {
   const { userAbility } = await requireUserAbility(request);
@@ -31,7 +32,9 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const { permissionId } = await params;
 
   try {
-    await deletePermission(permissionId);
+    const deletedPermission = await deletePermission(permissionId);
+    invalidateUserAbilityCacheByRoleId(deletedPermission.roleId);
+
     return NextResponse.json({ success: true });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/app/api/roles/[roleId]/permissions/[permissionId]/route.ts
+++ b/app/api/roles/[roleId]/permissions/[permissionId]/route.ts
@@ -33,7 +33,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
 
   try {
     const deletedPermission = await deletePermission(permissionId);
-    invalidateUserAbilityCacheByRoleId(deletedPermission.roleId);
+    await invalidateUserAbilityCacheByRoleId(deletedPermission.roleId);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/roles/[roleId]/permissions/route.ts
+++ b/app/api/roles/[roleId]/permissions/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       body.dataSourceId,
       body.websiteId,
     );
-    invalidateUserAbilityCacheByRoleId(roleId);
+    await invalidateUserAbilityCacheByRoleId(roleId);
 
     return NextResponse.json({ success: true, permission });
   } catch (error) {

--- a/app/api/roles/[roleId]/permissions/route.ts
+++ b/app/api/roles/[roleId]/permissions/route.ts
@@ -3,6 +3,7 @@ import { createPermission, getRolePermissions } from '~/lib/services/permissionS
 import { getRole } from '~/lib/services/roleService';
 import { requireUserAbility } from '~/auth/session';
 import { PermissionAction, PermissionResource } from '@prisma/client';
+import { invalidateUserAbilityCacheByRoleId } from '~/lib/casl/user-ability';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ roleId: string }> }) {
   const { userAbility } = await requireUserAbility(request);
@@ -50,6 +51,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       body.dataSourceId,
       body.websiteId,
     );
+    invalidateUserAbilityCacheByRoleId(roleId);
 
     return NextResponse.json({ success: true, permission });
   } catch (error) {

--- a/app/api/roles/[roleId]/users/[userId]/route.ts
+++ b/app/api/roles/[roleId]/users/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { userService } from '~/lib/services/userService';
 import { requireUserAbility } from '~/auth/session';
 import { PermissionAction, PermissionResource, Prisma } from '@prisma/client';
+import { invalidateUserAbilityCache } from '~/lib/casl/user-ability';
 
 export async function DELETE(
   request: NextRequest,
@@ -17,6 +18,8 @@ export async function DELETE(
 
   try {
     await userService.removeUserFromRole(userId, roleId);
+    invalidateUserAbilityCache(userId);
+
     return NextResponse.json({ success: true });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/app/api/roles/[roleId]/users/route.ts
+++ b/app/api/roles/[roleId]/users/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { userService } from '~/lib/services/userService';
 import { requireUserAbility } from '~/auth/session';
 import { PermissionAction, PermissionResource, Prisma } from '@prisma/client';
+import { invalidateUserAbilityCache } from '~/lib/casl/user-ability';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ roleId: string }> }) {
   const { userAbility } = await requireUserAbility(request);
@@ -32,6 +33,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
   try {
     const user = await userService.addUserToRole(body.userId, roleId);
+    invalidateUserAbilityCache(body.userId);
+
     return NextResponse.json({ success: true, user });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {


### PR DESCRIPTION
This PR includes invalidation of the User Ability Cache. When Users are added/removed from a role, their individual cache will be invalidated. When permissions to a role are changed, all associated users will have the cache invalidated.