### PR TITLE
Fix/eng 825/remove email and name

### DIFF
--- a/app/lib/services/userService.ts
+++ b/app/lib/services/userService.ts
@@ -4,8 +4,6 @@ import type { User } from '@prisma/client';
 
 export interface UserProfile {
   id: string;
-  name: string;
-  email: string;
   role: DeprecatedRole;
   organizationId: string;
   telemetryEnabled: boolean | null;
@@ -49,10 +47,8 @@ type UserWithRoles = Partial<User> & {
 };
 
 function mapToUserProfile(user: UserWithRoles): UserProfile {
-  const userProfile = {
+  const userProfile: UserProfile = {
     id: user.id,
-    name: user.name,
-    email: user.email,
     role: user.role,
     organizationId: user.organizationId!,
     telemetryEnabled: user.telemetryEnabled,

--- a/app/lib/services/userService.ts
+++ b/app/lib/services/userService.ts
@@ -4,6 +4,8 @@ import type { User } from '@prisma/client';
 
 export interface UserProfile {
   id: string;
+  name: string;
+  email: string;
   role: DeprecatedRole;
   organizationId: string;
   telemetryEnabled: boolean | null;

--- a/app/lib/telemetry/telemetry-manager.ts
+++ b/app/lib/telemetry/telemetry-manager.ts
@@ -52,13 +52,13 @@ class TelemetryManager {
   }
 
   async trackTelemetryEvent(event: TelemetryEvent, user?: UserProfile): Promise<void> {
-    type RemovePIIUserProfile = Omit<UserProfile, 'email' | 'name'> | undefined;
-
-    const safeUserProfile: RemovePIIUserProfile = user;
-
     if (!this._isTelemetryEnabled(user) || !this._posthogClient) {
       return;
     }
+
+    type RemovePIIUserProfile = Omit<UserProfile, 'email' | 'name'> | undefined;
+
+    const safeUserProfile: RemovePIIUserProfile = user;
 
     // Machine id is used to uniquely identify events per user
     const eventProperties = {

--- a/app/lib/telemetry/telemetry-manager.ts
+++ b/app/lib/telemetry/telemetry-manager.ts
@@ -52,6 +52,10 @@ class TelemetryManager {
   }
 
   async trackTelemetryEvent(event: TelemetryEvent, user?: UserProfile): Promise<void> {
+    type RemovePIIUserProfile = Omit<UserProfile, 'email' | 'name'> | undefined;
+
+    const safeUserProfile: RemovePIIUserProfile = user;
+
     if (!this._isTelemetryEnabled(user) || !this._posthogClient) {
       return;
     }
@@ -59,7 +63,7 @@ class TelemetryManager {
     // Machine id is used to uniquely identify events per user
     const eventProperties = {
       ...event.properties,
-      user,
+      safeUserProfile,
       instanceId: this._instanceId,
       nodeVersion: process.version,
       liblabVersion: env.npm_package_version || '0.0.1',


### PR DESCRIPTION
## 📋 Pull Request Summary

Currently, we capture the user email and name to Posthog when they enter a chat prompt.
We say that we won't do this in our telemetry notice when they first start using builder, so we shouldn't do it.


### 🔗 Related Issues

https://linear.app/liblab/issue/ENG-825/remove-email-and-name-from-user-information-in-posthog

### 📝 Changes Made

Removed user info from send to Posthog.  Also not sending user id or org to be fair.

<!-- Check the type of change -->

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements