### PR TITLE
[Hotfix] Gracefully handle postgres vs postgresql plugin identifier

### DIFF
--- a/shared/src/data-access/dataAccessor.ts
+++ b/shared/src/data-access/dataAccessor.ts
@@ -24,8 +24,10 @@ export class DataAccessor {
 
   static getByDatabaseType(databaseType: string): BaseAccessor | null {
     const allAccessors = this._getAllAccessors();
-    const accessorClass = allAccessors.find((acc: BaseAccessorConstructor) => acc.pluginId === databaseType);
-
+    const accessorClass = allAccessors.find((acc: BaseAccessorConstructor) =>
+      databaseType.toLowerCase().startsWith(acc.pluginId),
+    );
+    
     if (!accessorClass) {
       return null;
     }

--- a/shared/src/data-access/dataAccessor.ts
+++ b/shared/src/data-access/dataAccessor.ts
@@ -24,10 +24,10 @@ export class DataAccessor {
 
   static getByDatabaseType(databaseType: string): BaseAccessor | null {
     const allAccessors = this._getAllAccessors();
-    const accessorClass = allAccessors.find((acc: BaseAccessorConstructor) =>
-      databaseType.toLowerCase().startsWith(acc.pluginId),
-    );
-    
+    const accessorClass = allAccessors
+      .sort((a, b) => b.pluginId.length - a.pluginId.length)
+      .find((acc) => databaseType.toLowerCase().startsWith(acc.pluginId.toLowerCase()));
+
     if (!accessorClass) {
       return null;
     }


### PR DESCRIPTION
This pull request introduces a small but important improvement to how the `DataAccessor` class selects the correct accessor for a given database type. The change makes the accessor selection logic more flexible by matching accessors whose `pluginId` is a prefix of the (lowercased) `databaseType`.

* Improved accessor selection logic in `DataAccessor.getByDatabaseType` to use a prefix match (case-insensitive) instead of strict equality, allowing for more robust plugin identification.

This should be refactored to be more robust, but this should fix current reported issues