### PR TITLE
Support running with SQLite or Postgres

### DIFF
--- a/app/lib/schema.ts
+++ b/app/lib/schema.ts
@@ -82,6 +82,7 @@ export async function setSchemaCache(connectionUrl: string, schema: any): Promis
     create: {
       connectionHash: hash,
       schemaData: JSON.stringify(schema),
+      suggestions: JSON.stringify([]), // Store as JSON string for SQLite compatibility
     },
   });
 
@@ -100,7 +101,21 @@ export async function getSuggestionsCache(
     where: { connectionHash: hash },
   });
 
-  if (!cached || !cached.suggestions || cached.suggestions.length === 0) {
+  if (!cached || !cached.suggestions) {
+    return null;
+  }
+
+  // Convert suggestions from JSON string to array
+  let suggestions: string[];
+
+  try {
+    suggestions = JSON.parse(cached.suggestions as string);
+  } catch (error) {
+    logger.error('Failed to parse suggestions JSON:', error);
+    return null;
+  }
+
+  if (suggestions.length === 0) {
     return null;
   }
 
@@ -108,7 +123,7 @@ export async function getSuggestionsCache(
     return null;
   }
 
-  return cached.suggestions;
+  return suggestions;
 }
 
 export async function setSuggestionsCache(
@@ -122,12 +137,12 @@ export async function setSuggestionsCache(
     where: { connectionHash: hash },
     update: {
       schemaData: JSON.stringify(schema),
-      suggestions,
+      suggestions: JSON.stringify(suggestions), // Store as JSON string for SQLite compatibility
     },
     create: {
       connectionHash: hash,
       schemaData: JSON.stringify(schema),
-      suggestions,
+      suggestions: JSON.stringify(suggestions), // Store as JSON string for SQLite compatibility
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "setup": "pnpm i && pnpm run prisma:generate && tsx setup.ts",
     "build": "next build",
     "dev": "tsx scripts/dev-with-db.ts && tsx pre-start.ts && next dev --turbo",
+    "try:dev": "cp .env.example .env && pnpm run setup && pnpm run use:sqlite && tsx pre-start.ts && next dev --turbo",
     "test": "jest",
     "start": "tsx setup-tunnel.ts && tsx run-migrations.ts && next start",
     "prod": "pnpm run build && pnpm run start",
@@ -42,7 +43,10 @@
     "test:e2e:headed": "tsx scripts/run-e2e-tests.ts headed",
     "test:e2e:ui": "tsx scripts/run-e2e-tests.ts ui",
     "test:e2e:debug": "tsx scripts/run-e2e-tests.ts debug",
-    "test:e2e:headless": "tsx scripts/run-e2e-tests.ts headless"
+    "test:e2e:headless": "tsx scripts/run-e2e-tests.ts headless",
+    "use:sqlite": "tsx scripts/use-sqlite.ts",
+    "use:postgresql": "tsx scripts/use-postgresql.ts",
+    "migrate:suggestions": "tsx scripts/migrate-suggestions-to-json.ts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,7 +85,7 @@ model SchemaCache {
   id             String   @id @default(cuid())
   connectionHash String   @unique @map("connection_hash")
   schemaData     String   @map("schema_data")
-  suggestions    String[] @map("suggestions")
+  suggestions    String @map("suggestions")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 

--- a/scripts/use-sqlite.ts
+++ b/scripts/use-sqlite.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function updateEnvFileForSqlite(silent: boolean = false): void {
+  const envPath = '.env';
+  const databaseUrl = 'DATABASE_URL="file:./liblab.db"';
+
+  let envContent = '';
+
+  if (existsSync(envPath)) {
+    envContent = readFileSync(envPath, 'utf8');
+  }
+
+  // Check if DATABASE_URL already exists in the file
+  const lines = envContent.split('\n');
+  const databaseUrlIndex = lines.findIndex((line) => line.startsWith('DATABASE_URL='));
+
+  if (databaseUrlIndex !== -1) {
+    // Update existing DATABASE_URL
+    lines[databaseUrlIndex] = databaseUrl;
+  } else {
+    // Add new DATABASE_URL
+    lines.push(databaseUrl);
+  }
+
+  // Write back to .env file
+  writeFileSync(envPath, lines.join('\n'));
+
+  if (!silent) {
+    console.log('📝 Updated .env file with SQLite DATABASE_URL');
+  }
+}
+
+function updatePrismaSchemaToSqlite(silent: boolean = false): void {
+  const prismaSchemaPath = 'prisma/schema.prisma';
+
+  if (!existsSync(prismaSchemaPath)) {
+    if (!silent) {
+      console.error('❌ Prisma schema file not found at prisma/schema.prisma');
+    }
+
+    process.exit(1);
+  }
+
+  if (!silent) {
+    console.log('🔄 Updating Prisma schema to use SQLite...');
+    console.log('📋 Backup created at prisma/schema.prisma.backup');
+  }
+
+  let schemaContent = readFileSync(prismaSchemaPath, 'utf8');
+
+  // Replace PostgreSQL provider with SQLite
+  schemaContent = schemaContent.replace(/provider = "postgresql"/g, 'provider = "sqlite"');
+
+  // Update URL to use SQLite file
+  schemaContent = schemaContent.replace(/url\s*=\s*env\("DATABASE_URL"\)/g, 'url = env("DATABASE_URL")');
+
+  // Update SchemaCache suggestions field to use Json for SQLite compatibility
+  schemaContent = schemaContent.replace(/suggestions\s+String\[\]/g, 'suggestions    String');
+
+  writeFileSync(prismaSchemaPath, schemaContent, 'utf8');
+
+  // Remove migrations directory and create fresh SQLite migrations
+  try {
+    if (!silent) {
+      console.log('🗑️  Removing existing migrations directory...');
+    }
+
+    // Remove migrations directory completely
+    execSync('rm -rf prisma/migrations', { stdio: silent ? 'ignore' : 'inherit' });
+
+    if (!silent) {
+      console.log('✅ Removed existing migrations directory');
+      console.log('🔄 Creating initial SQLite migration...');
+    }
+
+    // Create initial migration for SQLite
+    execSync('npx prisma migrate dev --name init', { stdio: silent ? 'ignore' : 'inherit' });
+
+    if (!silent) {
+      console.log('✅ Initial SQLite migration created and applied successfully');
+    }
+  } catch (error) {
+    if (!silent) {
+      console.warn('⚠️  Could not create SQLite migrations:', (error as Error).message);
+    }
+  }
+
+  if (!silent) {
+    console.log('✅ Prisma schema updated successfully to use SQLite');
+    console.log('📝 Next steps:');
+    console.log('   1. Run: pnpm run dev');
+    console.log('');
+    console.log('💡 Note: SchemaCache.suggestions field changed from String[] to Json for SQLite compatibility');
+    console.log('📋 Original schema backed up to prisma/schema.prisma.backup');
+    console.log('✅ Database is ready with initial migration applied');
+  }
+}
+
+// Check for silent flag
+const silent = process.argv.includes('--silent') || process.argv.includes('-s');
+
+// Update .env file first
+updateEnvFileForSqlite(silent);
+
+// Run the script
+updatePrismaSchemaToSqlite(silent);

--- a/scripts/use-sqlite.ts
+++ b/scripts/use-sqlite.ts
@@ -46,7 +46,6 @@ function updatePrismaSchemaToSqlite(silent: boolean = false): void {
 
   if (!silent) {
     console.log('🔄 Updating Prisma schema to use SQLite...');
-    console.log('📋 Backup created at prisma/schema.prisma.backup');
   }
 
   let schemaContent = readFileSync(prismaSchemaPath, 'utf8');
@@ -93,8 +92,7 @@ function updatePrismaSchemaToSqlite(silent: boolean = false): void {
     console.log('📝 Next steps:');
     console.log('   1. Run: pnpm run dev');
     console.log('');
-    console.log('💡 Note: SchemaCache.suggestions field changed from String[] to Json for SQLite compatibility');
-    console.log('📋 Original schema backed up to prisma/schema.prisma.backup');
+    console.log('💡 Note: SchemaCache.suggestions field changed from String[] to String for SQLite compatibility');
     console.log('✅ Database is ready with initial migration applied');
   }
 }

--- a/scripts/use-sqlite.ts
+++ b/scripts/use-sqlite.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
 function updateEnvFileForSqlite(silent: boolean = false): void {
@@ -68,7 +68,7 @@ function updatePrismaSchemaToSqlite(silent: boolean = false): void {
     }
 
     // Remove migrations directory completely
-    execSync('rm -rf prisma/migrations', { stdio: silent ? 'ignore' : 'inherit' });
+    rmSync('prisma/migrations', { recursive: true, force: true });
 
     if (!silent) {
       console.log('✅ Removed existing migrations directory');


### PR DESCRIPTION
Added a script that allows ephemeral installations to switch to sqlite. Note this is not something that should be run when developing the application or when deploying the application as it will remove all migration history. This is purely to power the "try" mode