### PR TITLE
Add env var for disabling built app error autofixing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_POSTHOG_KEY=phc_C1L7Idffoa2oRT54XZDGh4GSdOPFgzliJiusFnVV8Wz
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 NEXT_PUBLIC_DISABLE_TELEMETRY=false
 
+# Disables built application error autofixing 
+NEXT_PUBLIC_DISABLE_AUTOFIX=false
+
 # Server private env vars
 LICENSE_KEY=free
 BASE_URL=http://localhost:3000

--- a/app/env/client.ts
+++ b/app/env/client.ts
@@ -9,16 +9,9 @@ export const env = createEnv({
     NEXT_PUBLIC_LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
     NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
     NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
-    NEXT_PUBLIC_USE_GOOGLE_AUTH: z
-      .preprocess((value) => {
-        return typeof value === 'string' ? JSON.parse(value) : value;
-      }, z.boolean())
-      .default(false),
-    NEXT_PUBLIC_DISABLE_TELEMETRY: z
-      .preprocess((value) => {
-        return typeof value === 'string' ? JSON.parse(value) : value;
-      }, z.boolean())
-      .default(false),
+    NEXT_PUBLIC_DISABLE_AUTOFIX: z.coerce.boolean().default(false),
+    NEXT_PUBLIC_USE_GOOGLE_AUTH: z.coerce.boolean().default(false),
+    NEXT_PUBLIC_DISABLE_TELEMETRY: z.coerce.boolean().default(false),
     NEXT_PUBLIC_GITHUB_ACCESS_TOKEN: z.string().optional(),
   },
   runtimeEnv: {
@@ -31,5 +24,6 @@ export const env = createEnv({
     NEXT_PUBLIC_BASE_URL: process.env.BASE_URL,
     NEXT_PUBLIC_NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_USE_GOOGLE_AUTH: !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET),
+    NEXT_PUBLIC_DISABLE_AUTOFIX: process.env.NEXT_PUBLIC_DISABLE_AUTOFIX,
   },
 });

--- a/app/lib/error-handler.ts
+++ b/app/lib/error-handler.ts
@@ -6,6 +6,7 @@ import { trackTelemetryEvent } from '~/lib/telemetry/telemetry-client';
 import { TelemetryEventType } from '~/lib/telemetry/telemetry-types';
 import { chatId } from '~/lib/persistence';
 import { createScopedLogger } from '~/utils/logger';
+import { env } from '~/env/client';
 
 interface ErrorState {
   lastAutofixAttempt?: number;
@@ -194,6 +195,11 @@ export class ErrorHandler {
   }
 
   #shouldAutofix(now: number) {
+    if (env.NEXT_PUBLIC_DISABLE_AUTOFIX) {
+      logger.debug('Skipping autofix event because NEXT_PUBLIC_DISABLE_AUTOFIX set to true');
+      return false;
+    }
+
     const state = this.#state.get();
 
     return !state.lastAutofixAttempt || now - state.lastAutofixAttempt >= this.#AUTOFIX_COOLDOWN_MS;


### PR DESCRIPTION
This is useful for local development where the errors are expected. Having control over autofixing is both time and money saver.

It is false by default, and if set to true, errors are not autofixed. 