### PR TITLE
Add dynamic roles for specific resource permissions and sharing

### DIFF
--- a/app/api/[resource]/[resourceId]/members/[memberId]/route.ts
+++ b/app/api/[resource]/[resourceId]/members/[memberId]/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { userService } from '~/lib/services/userService';
+import { getResourceRoleByUser } from '~/lib/services/roleService';
+import { requireUserAbility } from '~/auth/session';
+import { PermissionAction, PermissionResource, Prisma, RoleScope } from '@prisma/client';
+import { invalidateUserAbilityCache } from '~/lib/casl/user-ability';
+import { prisma } from '~/lib/prisma';
+import { subject } from '@casl/ability';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ resource: string; resourceId: string; memberId: string }> },
+) {
+  const { userAbility } = await requireUserAbility(request);
+  const { resource, resourceId, memberId } = await params;
+  const roleScope = getRoleScope(resource);
+
+  if (!roleScope) {
+    return NextResponse.json({ success: false, error: 'Invalid route' }, { status: 400 });
+  }
+
+  const role = await getResourceRoleByUser(roleScope, resourceId, memberId);
+
+  if (!role) {
+    return NextResponse.json({ success: false, error: 'Role not found' }, { status: 404 });
+  }
+
+  if (!role.resourceId) {
+    return NextResponse.json({ success: false, error: 'Resource ID missing for scoped role' }, { status: 400 });
+  }
+
+  let resourceType: PermissionResource;
+  const resourceSubjectData: { id: string; createdById?: string } = { id: role.resourceId };
+
+  switch (role.scope) {
+    case RoleScope.ENVIRONMENT: {
+      resourceType = PermissionResource.Environment;
+
+      const environment = await prisma.environment.findUnique({
+        where: { id: role.resourceId },
+        select: { id: true },
+      });
+
+      if (!environment) {
+        return NextResponse.json({ success: false, error: 'Resource not found' }, { status: 404 });
+      }
+
+      break;
+    }
+    case RoleScope.DATA_SOURCE: {
+      resourceType = PermissionResource.DataSource;
+
+      const datasource = await prisma.dataSource.findUnique({
+        where: { id: role.resourceId },
+        select: { id: true, createdById: true },
+      });
+
+      if (!datasource) {
+        return NextResponse.json({ success: false, error: 'Resource not found' }, { status: 404 });
+      }
+
+      resourceSubjectData.createdById = datasource.createdById;
+      break;
+    }
+    case RoleScope.WEBSITE: {
+      resourceType = PermissionResource.Website;
+
+      const website = await prisma.website.findUnique({
+        where: { id: role.resourceId },
+        select: { id: true, createdById: true },
+      });
+
+      if (!website) {
+        return NextResponse.json({ success: false, error: 'Resource not found' }, { status: 404 });
+      }
+
+      resourceSubjectData.createdById = website.createdById;
+      break;
+    }
+
+    default:
+      return NextResponse.json({ success: false, error: 'Invalid role scope' }, { status: 400 });
+  }
+
+  if (!userAbility.can(PermissionAction.manage, subject(resourceType, resourceSubjectData))) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    await userService.removeUserFromRole(memberId, role.id);
+    invalidateUserAbilityCache(memberId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === 'P2025') {
+        return NextResponse.json({ success: false, error: 'User not found in this role' }, { status: 404 });
+      }
+    }
+
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Failed to remove user from role' },
+      { status: 400 },
+    );
+  }
+}
+
+function getRoleScope(resourceType: string) {
+  switch (resourceType.toLowerCase()) {
+    case 'data-sources':
+      return RoleScope.DATA_SOURCE;
+    case 'environments':
+      return RoleScope.ENVIRONMENT;
+    case 'websites':
+      return RoleScope.WEBSITE;
+    default:
+      return null;
+  }
+}

--- a/app/api/[resource]/[resourceId]/members/[memberId]/route.ts
+++ b/app/api/[resource]/[resourceId]/members/[memberId]/route.ts
@@ -11,73 +11,71 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ resource: string; resourceId: string; memberId: string }> },
 ) {
-  const { userAbility } = await requireUserAbility(request);
-  const { resource, resourceId, memberId } = await params;
-  const roleScope = getRoleScope(resource);
-
-  if (!roleScope) {
-    return NextResponse.json({ success: false, error: 'Invalid route' }, { status: 400 });
-  }
-
-  const role = await getResourceRoleByUser(roleScope, resourceId, memberId);
-
-  if (!role) {
-    return NextResponse.json({ success: false, error: 'Role not found' }, { status: 404 });
-  }
-
-  if (!role.resourceId) {
-    return NextResponse.json({ success: false, error: 'Resource ID missing for scoped role' }, { status: 400 });
-  }
-
-  const resourceMap = {
-    [RoleScope.ENVIRONMENT]: {
-      resourceType: PermissionResource.Environment,
-      model: prisma.environment,
-      select: { id: true },
-    },
-    [RoleScope.DATA_SOURCE]: {
-      resourceType: PermissionResource.DataSource,
-      model: prisma.dataSource,
-      select: { id: true, createdById: true },
-    },
-    [RoleScope.WEBSITE]: {
-      resourceType: PermissionResource.Website,
-      model: prisma.website,
-      select: { id: true, createdById: true },
-    },
-  };
-
-  const mapping = resourceMap[role.scope as keyof typeof resourceMap];
-
-  if (!mapping) {
-    return NextResponse.json({ success: false, error: 'Invalid role scope' }, { status: 400 });
-  }
-
-  const resourceType = mapping.resourceType;
-
-  const resourceData = await (mapping.model as any).findUnique({
-    where: { id: role.resourceId },
-    select: mapping.select,
-  });
-
-  if (!resourceData) {
-    return NextResponse.json({ success: false, error: 'Resource not found' }, { status: 404 });
-  }
-
-  if (resourceData.createdById) {
-    resourceData.createdById = resourceData.createdById;
-  }
-
-  if (!userAbility.can(PermissionAction.manage, subject(resourceType, resourceData))) {
-    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
-  }
-
   try {
+    const { userAbility } = await requireUserAbility(request);
+    const { resource, resourceId, memberId } = await params;
+    const roleScope = getRoleScope(resource);
+
+    const role = await getResourceRoleByUser(roleScope, resourceId, memberId);
+
+    if (!role) {
+      return NextResponse.json({ success: false, error: 'Role not found' }, { status: 404 });
+    }
+
+    if (!role.resourceId) {
+      return NextResponse.json({ success: false, error: 'Resource ID missing for scoped role' }, { status: 400 });
+    }
+
+    const resourceMap = {
+      [RoleScope.ENVIRONMENT]: {
+        resourceType: PermissionResource.Environment,
+        model: prisma.environment,
+        select: { id: true },
+      },
+      [RoleScope.DATA_SOURCE]: {
+        resourceType: PermissionResource.DataSource,
+        model: prisma.dataSource,
+        select: { id: true, createdById: true },
+      },
+      [RoleScope.WEBSITE]: {
+        resourceType: PermissionResource.Website,
+        model: prisma.website,
+        select: { id: true, createdById: true },
+      },
+    };
+
+    const mapping = resourceMap[role.scope as keyof typeof resourceMap];
+
+    if (!mapping) {
+      return NextResponse.json({ success: false, error: 'Invalid role scope' }, { status: 400 });
+    }
+
+    const resourceType = mapping.resourceType;
+
+    const resourceData = await (mapping.model as any).findUnique({
+      where: { id: role.resourceId },
+      select: mapping.select,
+    });
+
+    if (!resourceData) {
+      return NextResponse.json({ success: false, error: 'Resource not found' }, { status: 404 });
+    }
+
+    if (!userAbility.can(PermissionAction.manage, subject(resourceType, resourceData))) {
+      return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+    }
+
     await userService.removeUserFromRole(memberId, role.id);
     invalidateUserAbilityCache(memberId);
 
     return NextResponse.json({ success: true });
   } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.startsWith('Invalid resource type')) {
+        return NextResponse.json({ success: false, error: 'Invalid route' }, { status: 400 });
+      }
+    }
+
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2025') {
         return NextResponse.json({ success: false, error: 'User not found in this role' }, { status: 404 });
@@ -100,6 +98,6 @@ function getRoleScope(resourceType: string) {
     case 'websites':
       return RoleScope.WEBSITE;
     default:
-      return null;
+      throw new Error(`Invalid resource type provided: "${resourceType}"`);
   }
 }

--- a/app/api/[resource]/[resourceId]/members/route.ts
+++ b/app/api/[resource]/[resourceId]/members/route.ts
@@ -14,14 +14,14 @@ export async function POST(
   { params }: { params: Promise<{ resource: string; resourceId: string }> },
 ) {
   const { userAbility } = await requireUserAbility(request);
-  const { resource: resourcePath, resourceId } = await params;
-  const resourceTypeDetails = getResourceTypeDetails(resourcePath);
+  const { resource: resourceParam, resourceId } = await params;
+  const resourceConfig = getResourceConfig(resourceParam);
 
-  if (!resourceTypeDetails) {
-    return NextResponse.json({ success: false, error: 'Invalid resource type' }, { status: 400 });
+  if (!resourceConfig) {
+    return NextResponse.json({ success: false, error: 'Invalid route' }, { status: 400 });
   }
 
-  const { fetchFunction, permissionResource, roleScope, resourceLabel } = resourceTypeDetails;
+  const { fetchFunction, permissionResource, roleScope, resourceLabel } = resourceConfig;
 
   const resource = await fetchFunction(resourceId);
 
@@ -60,14 +60,14 @@ export async function POST(
   );
 }
 
-interface ResourceTypeDetails {
+interface ResourceConfig {
   fetchFunction: (id: string) => Promise<any>;
   permissionResource: PermissionResource;
   roleScope: ResourceRoleScope;
   resourceLabel: string;
 }
 
-function getResourceTypeDetails(resourceType: string): ResourceTypeDetails | null {
+function getResourceConfig(resourceType: string): ResourceConfig | null {
   switch (resourceType.toLowerCase()) {
     case 'data-sources':
       return {

--- a/app/api/[resource]/[resourceId]/members/route.ts
+++ b/app/api/[resource]/[resourceId]/members/route.ts
@@ -75,10 +75,14 @@ export async function POST(
     resourceLabel,
   );
 }
+interface ResourceForPermissionCheck {
+  id: string;
+  createdById?: string;
+}
 
 interface ResourceConfig {
-  fetchFunction: (id: string) => Promise<any>;
-  permissionResource: PermissionResource;
+  fetchFunction: (id: string) => Promise<ResourceForPermissionCheck | null>;
+  permissionResource: 'DataSource' | 'Environment' | 'Website';
   roleScope: ResourceRoleScope;
   resourceLabel: string;
 }

--- a/app/api/[resource]/[resourceId]/members/route.ts
+++ b/app/api/[resource]/[resourceId]/members/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { userService, type UserProfile } from '~/lib/services/userService';
+import { getDataSource } from '~/lib/services/datasourceService';
+import { getEnvironment } from '~/lib/services/environmentService';
+import { getWebsite } from '~/lib/services/websiteService';
+import { getPermissionLevelDetails, type PermissionLevel } from '~/lib/services/permissionService';
+import { findOrCreateResourceRole, type ResourceRoleScope } from '~/lib/services/roleService';
+import { requireUserAbility } from '~/auth/session';
+import { PermissionAction, PermissionResource, Prisma, RoleScope } from '@prisma/client';
+import { subject } from '@casl/ability';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ resource: string; resourceId: string }> },
+) {
+  const { userAbility } = await requireUserAbility(request);
+  const { resource: resourcePath, resourceId } = await params;
+  const resourceTypeDetails = getResourceTypeDetails(resourcePath);
+
+  if (!resourceTypeDetails) {
+    return NextResponse.json({ success: false, error: 'Invalid resource type' }, { status: 400 });
+  }
+
+  const { fetchFunction, permissionResource, roleScope, resourceLabel } = resourceTypeDetails;
+
+  const resource = await fetchFunction(resourceId);
+
+  if (!resource) {
+    return NextResponse.json({ success: false, error: `${resourceLabel} not found` }, { status: 404 });
+  }
+
+  if (userAbility.cannot(PermissionAction.manage, subject(permissionResource, resource))) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = (await request.json()) as {
+    email: string;
+    permissionLevel: string;
+  };
+
+  const permissionLevelDetails = getPermissionLevelDetails(body.permissionLevel);
+
+  if (!permissionLevelDetails) {
+    return NextResponse.json({ success: false, error: 'Invalid permission level' }, { status: 400 });
+  }
+
+  const user = await userService.getUserByEmail(body.email);
+
+  if (!user) {
+    return NextResponse.json({ success: false, error: 'User not found' }, { status: 404 });
+  }
+
+  return await assignUserToRole(
+    user,
+    resource,
+    roleScope,
+    permissionLevelDetails.level,
+    user.organizationId,
+    resourceLabel,
+  );
+}
+
+interface ResourceTypeDetails {
+  fetchFunction: (id: string) => Promise<any>;
+  permissionResource: PermissionResource;
+  roleScope: ResourceRoleScope;
+  resourceLabel: string;
+}
+
+function getResourceTypeDetails(resourceType: string): ResourceTypeDetails | null {
+  switch (resourceType.toLowerCase()) {
+    case 'data-sources':
+      return {
+        fetchFunction: getDataSource,
+        permissionResource: PermissionResource.DataSource,
+        roleScope: RoleScope.DATA_SOURCE,
+        resourceLabel: 'Data source',
+      };
+    case 'environments':
+      return {
+        fetchFunction: getEnvironment,
+        permissionResource: PermissionResource.Environment,
+        roleScope: RoleScope.ENVIRONMENT,
+        resourceLabel: 'Environment',
+      };
+    case 'websites':
+      return {
+        fetchFunction: getWebsite,
+        permissionResource: PermissionResource.Website,
+        roleScope: RoleScope.WEBSITE,
+        resourceLabel: 'Website',
+      };
+    default:
+      return null;
+  }
+}
+
+async function assignUserToRole(
+  user: UserProfile,
+  resource: any,
+  roleScope: ResourceRoleScope,
+  permissionLevel: PermissionLevel,
+  organizationId: string,
+  resourceLabel: string,
+): Promise<NextResponse> {
+  try {
+    const role = await findOrCreateResourceRole(roleScope, resource.id, permissionLevel, organizationId);
+
+    if (!role) {
+      return NextResponse.json({ success: false, error: 'Role not found or could not be created' }, { status: 404 });
+    }
+
+    const userProfile = await userService.addUserToRole(user.id, role.id);
+
+    return NextResponse.json({ success: true, user: userProfile });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return NextResponse.json({ success: false, error: 'User already exists in this role' }, { status: 400 });
+    }
+
+    const errorMessage = error instanceof Error ? error.message : `Failed to add user to role for ${resourceLabel}`;
+
+    return NextResponse.json({ success: false, error: errorMessage }, { status: 400 });
+  }
+}

--- a/app/api/data-sources/[id]/route.ts
+++ b/app/api/data-sources/[id]/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
   const { id } = await params;
 
-  const dataSource = await getDataSource(id, userId);
+  const dataSource = await getDataSource(id);
 
   if (!dataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
@@ -28,7 +28,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   const { id } = await params;
 
-  const dataSource = await getDataSource(id, userId);
+  const dataSource = await getDataSource(id);
 
   if (!dataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
@@ -54,7 +54,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const userId = await requireUserId(request);
   const { id } = await params;
 
-  const dataSource = await getDataSource(id, userId);
+  const dataSource = await getDataSource(id);
 
   if (!dataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });

--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createRole, getRoles } from '~/lib/services/roleService';
 import { organizationService } from '~/lib/services/organizationService';
 import { requireUserAbility } from '~/auth/session';
-import { PermissionAction, PermissionResource, Prisma } from '@prisma/client';
+import { PermissionAction, PermissionResource, Prisma, RoleScope } from '@prisma/client';
 
 export async function GET(request: NextRequest) {
   const { userAbility } = await requireUserAbility(request);
@@ -26,6 +26,8 @@ export async function POST(request: NextRequest) {
   const body = (await request.json()) as {
     name: string;
     description?: string;
+    scope?: RoleScope;
+    resourceId?: string;
   };
 
   const organization = await organizationService.getOrganizationByUser(userId);
@@ -35,7 +37,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const role = await createRole(body.name, body.description, organization.id);
+    const role = await createRole(body.name, body.description, organization.id, body.scope, body.resourceId);
 
     return NextResponse.json({ success: true, role });
   } catch (error) {

--- a/app/api/suggestions/route.ts
+++ b/app/api/suggestions/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDataSource } from '~/lib/services/datasourceService';
 import { generateSchemaBasedSuggestions } from '~/lib/services/suggestionService';
-import { requireUserId } from '~/auth/session';
 import { SAMPLE_DATABASE_NAME } from '@liblab/data-access/accessors/sqlite';
 import { logger } from '~/utils/logger';
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = await requireUserId(request);
     const { dataSourceId } = await request.json<{ dataSourceId: string }>();
 
     if (!dataSourceId) {
@@ -15,7 +13,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Fetch the data source using the service
-    const dataSource = await getDataSource(dataSourceId, userId);
+    const dataSource = await getDataSource(dataSourceId);
 
     if (!dataSource) {
       return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });

--- a/app/lib/services/datasourceService.ts
+++ b/app/lib/services/datasourceService.ts
@@ -8,17 +8,19 @@ export interface DataSource {
   id: string;
   name: string;
   connectionString: string;
+  createdById: string;
   createdAt: Date;
   updatedAt: Date;
 }
 
-export async function getDataSource(id: string, userId: string): Promise<DataSource | null> {
-  return prisma.dataSource.findFirst({
-    where: { id, createdById: userId },
+export async function getDataSource(id: string): Promise<DataSource | null> {
+  return prisma.dataSource.findUnique({
+    where: { id },
     select: {
       id: true,
       name: true,
       connectionString: true,
+      createdById: true,
       createdAt: true,
       updatedAt: true,
     },
@@ -38,6 +40,7 @@ export async function getDataSources(userAbility: AppAbility): Promise<DataSourc
       id: true,
       name: true,
       connectionString: true,
+      createdById: true,
       createdAt: true,
       updatedAt: true,
     },

--- a/app/lib/services/permissionService.ts
+++ b/app/lib/services/permissionService.ts
@@ -2,6 +2,44 @@ import { prisma } from '@/lib/prisma';
 import { PermissionAction, PermissionResource } from '@prisma/client';
 import type { Permission } from '@prisma/client';
 
+export type PermissionLevel = 'viewer' | 'manage';
+export interface PermissionDetails {
+  label: string;
+  action: PermissionAction;
+}
+
+export const permissionLevels: Record<PermissionLevel, PermissionDetails> = {
+  viewer: {
+    label: 'VIEWER',
+    action: PermissionAction.read,
+  },
+  manage: {
+    label: 'MANAGE',
+    action: PermissionAction.manage,
+  },
+} as const;
+
+/**
+ * Validates and retrieves permission level case-insensitively.
+ * Returns null if invalid.
+ */
+export function getPermissionLevelDetails(
+  input: unknown,
+): { level: PermissionLevel; details: PermissionDetails } | null {
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const normalizedLevel = input.toLowerCase();
+
+  if (normalizedLevel in permissionLevels) {
+    const level = normalizedLevel as PermissionLevel;
+    return { level, details: permissionLevels[level] };
+  }
+
+  return null;
+}
+
 export async function getUserPermissions(userId: string): Promise<Permission[]> {
   const userWithRoles = await prisma.user.findUnique({
     where: { id: userId },

--- a/app/lib/services/permissionService.ts
+++ b/app/lib/services/permissionService.ts
@@ -24,13 +24,9 @@ export const permissionLevels: Record<PermissionLevel, PermissionDetails> = {
  * Returns null if invalid.
  */
 export function getPermissionLevelDetails(
-  input: unknown,
+  levelInput: string,
 ): { level: PermissionLevel; details: PermissionDetails } | null {
-  if (typeof input !== 'string') {
-    return null;
-  }
-
-  const normalizedLevel = input.toLowerCase();
+  const normalizedLevel = levelInput.toLowerCase();
 
   if (normalizedLevel in permissionLevels) {
     const level = normalizedLevel as PermissionLevel;

--- a/app/lib/services/roleService.ts
+++ b/app/lib/services/roleService.ts
@@ -1,6 +1,6 @@
 import { prisma } from '~/lib/prisma';
 import { RoleScope } from '@prisma/client';
-import { type Role, PermissionResource } from '@prisma/client';
+import { type Role, PermissionAction, PermissionResource } from '@prisma/client';
 import { permissionLevels, type PermissionLevel } from '~/lib/services/permissionService';
 
 export type ResourceRoleScope = Exclude<RoleScope, 'GENERAL'>;
@@ -79,7 +79,7 @@ export async function findOrCreateResourceRole(
   }
 
   const permissionData: {
-    action: any;
+    action: PermissionAction;
     resource: PermissionResource;
     dataSourceId?: string;
     environmentId?: string;

--- a/app/lib/services/roleService.ts
+++ b/app/lib/services/roleService.ts
@@ -1,5 +1,15 @@
 import { prisma } from '~/lib/prisma';
-import type { Role } from '@prisma/client';
+import { RoleScope } from '@prisma/client';
+import { type Role, PermissionResource } from '@prisma/client';
+import { permissionLevels, type PermissionLevel } from '~/lib/services/permissionService';
+
+export type ResourceRoleScope = Exclude<RoleScope, 'GENERAL'>;
+
+export const roleScopeResourceMap: Record<ResourceRoleScope, PermissionResource> = {
+  [RoleScope.DATA_SOURCE]: PermissionResource.DataSource,
+  [RoleScope.ENVIRONMENT]: PermissionResource.Environment,
+  [RoleScope.WEBSITE]: PermissionResource.Website,
+};
 
 export async function getRole(id: string): Promise<Role | null> {
   return prisma.role.findUnique({
@@ -32,21 +42,80 @@ export async function getRoles(): Promise<Role[]> {
   }));
 }
 
+export async function findOrCreateResourceRole(
+  scope: ResourceRoleScope,
+  resourceId: string,
+  permissionLevel: PermissionLevel,
+  organizationId: string,
+): Promise<Role | null> {
+  const permissionDetails = permissionLevels[permissionLevel];
+
+  const name = `${scope}_${permissionDetails.label}_${resourceId}`;
+
+  const existingRole = await prisma.role.findFirst({
+    where: { scope, resourceId, name, organizationId },
+  });
+
+  if (existingRole) {
+    return existingRole;
+  }
+
+  const permissionData: {
+    action: any;
+    resource: PermissionResource;
+    dataSourceId?: string;
+    environmentId?: string;
+    websiteId?: string;
+  } = {
+    action: permissionDetails.action,
+    resource: roleScopeResourceMap[scope],
+  };
+
+  switch (scope) {
+    case RoleScope.DATA_SOURCE:
+      permissionData.dataSourceId = resourceId;
+      break;
+    case RoleScope.ENVIRONMENT:
+      permissionData.environmentId = resourceId;
+      break;
+    case RoleScope.WEBSITE:
+      permissionData.websiteId = resourceId;
+      break;
+  }
+
+  return prisma.role.create({
+    data: {
+      name,
+      description: `Grants ${permissionLevel} access to ${scope} ${resourceId}`,
+      organizationId,
+      scope,
+      resourceId,
+      permissions: {
+        create: permissionData,
+      },
+    },
+  });
+}
+
 export async function createRole(
   name: string,
   description: string | undefined = undefined,
   organizationId: string,
+  scope: RoleScope = RoleScope.GENERAL,
+  resourceId?: string,
 ): Promise<Role> {
   return prisma.role.create({
     data: {
       name,
       description: description || null,
       organizationId,
+      scope,
+      resourceId,
     },
   });
 }
 
-export async function updateRole(id: string, name: string, description: string | undefined = undefined): Promise<Role> {
+export async function updateRole(id: string, name: string, description?: string): Promise<Role> {
   return prisma.role.update({
     where: { id },
     data: {

--- a/app/lib/services/roleService.ts
+++ b/app/lib/services/roleService.ts
@@ -42,6 +42,24 @@ export async function getRoles(): Promise<Role[]> {
   }));
 }
 
+export async function getResourceRoleByUser(
+  scope: ResourceRoleScope,
+  resourceId: string,
+  userId: string,
+): Promise<Role | null> {
+  return await prisma.role.findFirst({
+    where: {
+      scope,
+      resourceId,
+      users: {
+        some: {
+          userId,
+        },
+      },
+    },
+  });
+}
+
 export async function findOrCreateResourceRole(
   scope: ResourceRoleScope,
   resourceId: string,

--- a/app/lib/services/userService.ts
+++ b/app/lib/services/userService.ts
@@ -50,7 +50,7 @@ export const userService = {
 
   async getUserByEmail(email: string): Promise<UserProfile> {
     const user = await prisma.user.findUnique({
-      where: { email }
+      where: { email },
     });
 
     if (!user) {
@@ -64,7 +64,6 @@ export const userService = {
       image: user.image,
       role: user.role,
       organizationId: user.organizationId,
-      organization: user.organization,
       telemetryEnabled: user.telemetryEnabled,
     };
   },

--- a/app/lib/services/userService.ts
+++ b/app/lib/services/userService.ts
@@ -83,6 +83,19 @@ export const userService = {
     return mapToUserProfile(user);
   },
 
+  async getUserByEmail(email: string): Promise<UserProfile | null> {
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: userSelectWithRoles,
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    return mapToUserProfile(user);
+  },
+
   async updateUser(userId: string, data: UserUpdateData): Promise<UserProfile> {
     const user = await prisma.user.update({
       where: { id: userId },

--- a/app/lib/services/websiteService.ts
+++ b/app/lib/services/websiteService.ts
@@ -1,0 +1,8 @@
+import { prisma } from '~/lib/prisma';
+import type { Website } from '@prisma/client';
+
+export async function getWebsite(id: string): Promise<Website | null> {
+  return prisma.website.findUnique({
+    where: { id },
+  });
+}

--- a/prisma/migrations/20250819212205_add_role_scope/migration.sql
+++ b/prisma/migrations/20250819212205_add_role_scope/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "public"."RoleScope" AS ENUM ('GENERAL', 'ENVIRONMENT', 'DATA_SOURCE', 'WEBSITE');
+
+-- AlterTable
+ALTER TABLE "public"."role" ADD COLUMN     "resource_id" TEXT,
+ADD COLUMN     "scope" "public"."RoleScope" NOT NULL DEFAULT 'GENERAL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,12 +143,21 @@ model Snapshot {
   @@map("snapshot")
 }
 
+enum RoleScope {
+  GENERAL
+  ENVIRONMENT
+  DATA_SOURCE
+  WEBSITE
+}
+
 model Role {
   id             String       @id @default(cuid())
   name           String
   description    String?
   organizationId String       @map("organization_id")
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  scope          RoleScope    @default(GENERAL)
+  resourceId     String?      @map("resource_id")
   users          UserRole[]
   permissions    Permission[]
   createdAt      DateTime     @default(now()) @map("created_at")


### PR DESCRIPTION
This PR adds support for Dynamic Resource Roles. It supports a member with permissions sharing a resource (Environment, Data Source, Website) with other users in the system. The "add member" API will create, or reuse if existing, the dynamic resource role appropriate for the permission level (Full Access/manage or Viewer/read) desired to grant. An API has also been added for the reverse, to remove a user from permissions to a resource.

Scope and resourceId have been added to roles to support and differentiate an organization wide or general role with a resource specific role (the dynamic resource role described).

Because of the overlap of functionality to add / remove users from a resource, this was done in a centralized place and leveraging parameterization in Next's app router.