### PR TITLE
Add the ADMIN role to the first user that logs in

### DIFF
--- a/app/lib/services/userService.ts
+++ b/app/lib/services/userService.ts
@@ -215,10 +215,13 @@ export const userService = {
 
   async grantSystemAdminAccess(userId: string, organizationId: string): Promise<void> {
     try {
-      // First, ensure the user has the organizationId set
+      // First, ensure the user has the organizationId set and role set to ADMIN
       await prisma.user.update({
         where: { id: userId },
-        data: { organizationId },
+        data: {
+          organizationId,
+          role: DeprecatedRole.ADMIN, // Set legacy role field to ADMIN for first user
+        },
       });
 
       // Create a System Admin role if it doesn't exist


### PR DESCRIPTION
This pull request updates the logic for granting system admin access in the `userService`. The main change ensures that when a user's `organizationId` is set, their legacy `role` field is also explicitly set to `ADMIN`, which helps maintain compatibility for legacy role checks.

User role and organization assignment:

* Updated the `grantSystemAdminAccess` method in `userService.ts` to set both the `organizationId` and legacy `role` field to `ADMIN` when granting system admin access. This ensures the user's role is correctly set for legacy systems when they become the first admin in an organization.