### PR TITLE
Fix dialogue boxes not being centered

### DIFF
--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -69,15 +69,14 @@ export const dialogBackdropVariants = {
 
 export const dialogVariants = {
   closed: {
-    x: '-50%',
-    y: '-40%',
+    // Do not animate x/y here — leave positioning to the CSS classes
+    // (top-1/2 left-1/2 + -translate-x-1/2 -translate-y-1/2) so we don't
+    // override the transform via inline styles. Only animate scale/opacity.
     scale: 0.96,
     opacity: 0,
     transition,
   },
   open: {
-    x: '-50%',
-    y: '-50%',
     scale: 1,
     opacity: 1,
     transition,


### PR DESCRIPTION
Remove x/y animation from dialogVariants, relying on CSS for positioning to avoid conflicts with inline styles. Only scale and opacity will be animated.