### PR TITLE
Remove Deprecated Role

### DIFF
--- a/app/api/me/ability/route.ts
+++ b/app/api/me/ability/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireUserAbility } from '~/auth/session';
+import { logger } from '~/utils/logger';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userAbility } = await requireUserAbility(request);
+
+    return NextResponse.json({ success: true, rules: userAbility.rules });
+  } catch (error) {
+    logger.error('Error fetching user ability:', error);
+    return NextResponse.json({ success: false, error: 'Failed to fetch user ability' }, { status: 500 });
+  }
+}

--- a/app/components/@settings/core/ControlPanel.tsx
+++ b/app/components/@settings/core/ControlPanel.tsx
@@ -19,8 +19,8 @@ import { Settings } from 'lucide-react';
 import DataTab from '~/components/@settings/tabs/data/DataTab';
 import DeployedAppsTab from '~/components/@settings/tabs/deployed-apps/DeployedAppsTab';
 import GitHubTab from '~/components/@settings/tabs/connections/GitHubTab';
-import { useUserStore } from '~/lib/stores/user';
-import { DeprecatedRole } from '@prisma/client';
+import { Can } from '@casl/react';
+import { AbilityContext } from '~/components/ability/AbilityProvider';
 import MembersTab from '~/components/@settings/tabs/users/UsersTab';
 import RolesTab from '~/components/@settings/tabs/roles/RolesTab';
 import EnvironmentsTab from '~/components/@settings/tabs/environments';
@@ -84,8 +84,6 @@ export const ControlPanel = () => {
 
   // Store values
   const tabConfiguration = useStore(tabConfigurationStore);
-  const { user } = useUserStore();
-  const role = user?.role;
 
   // Memoize the base tab configurations to avoid recalculation
   const baseTabConfig = useMemo(() => {
@@ -222,11 +220,11 @@ export const ControlPanel = () => {
                 <div className="flex-1 overflow-y-auto p-4">
                   <TabSection title="Workspace" tabs={visibleTabs} activeTab={activeTab} onTabClick={handleTabClick} />
 
-                  {role === DeprecatedRole.ADMIN && (
+                  <Can I="view" a="AdminApp" ability={React.useContext(AbilityContext)}>
                     <div className="mt-6">
                       <TabSection title="Admin" tabs={adminTabs} activeTab={activeTab} onTabClick={handleTabClick} />
                     </div>
-                  )}
+                  </Can>
                 </div>
               </div>
 

--- a/app/components/ClientProviders.tsx
+++ b/app/components/ClientProviders.tsx
@@ -5,6 +5,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Toaster } from 'sonner';
 import { AuthProvider } from './auth/AuthContext';
 import { DataLoader, type RootData } from './DataLoader';
+import { AbilityProvider } from './ability/AbilityProvider';
 
 interface ClientProvidersProps {
   children: React.ReactNode;
@@ -16,8 +17,10 @@ export function ClientProviders({ children, rootData }: ClientProvidersProps) {
     <AuthProvider>
       <DndProvider backend={HTML5Backend}>
         <DataLoader rootData={rootData}>
-          {children}
-          <Toaster richColors />
+          <AbilityProvider>
+            {children}
+            <Toaster richColors />
+          </AbilityProvider>
         </DataLoader>
       </DndProvider>
     </AuthProvider>

--- a/app/components/ability/AbilityProvider.tsx
+++ b/app/components/ability/AbilityProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { createContext } from 'react';
+import { createPrismaAbility } from '@casl/prisma';
+import { useEffect, useMemo, useState } from 'react';
+import { useUserStore } from '~/lib/stores/user';
+import type { RawRule } from '@casl/ability';
+import type { AppAbility } from '~/lib/casl/user-ability';
+import { logger } from '~/utils/logger';
+
+export const AbilityContext = createContext<AppAbility>(createPrismaAbility([]));
+
+interface AbilityProviderProps {
+  children: React.ReactNode;
+}
+
+export function AbilityProvider({ children }: AbilityProviderProps) {
+  const { user } = useUserStore();
+  const [rules, setRules] = useState<RawRule[]>([]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      setRules([]);
+      return;
+    }
+
+    const fetchAbility = async () => {
+      try {
+        const response = await fetch('/api/me/ability');
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch ability rules');
+        }
+
+        const data: { success: boolean; rules: RawRule[] } = await response.json();
+        setRules(data.rules || []);
+      } catch (error) {
+        logger.error('Error fetching ability:', error);
+        setRules([]);
+      }
+    };
+
+    fetchAbility();
+  }, [user?.id]);
+
+  const ability = useMemo(() => createPrismaAbility(rules), [rules]);
+
+  return <AbilityContext.Provider value={ability}>{children}</AbilityContext.Provider>;
+}

--- a/app/components/ability/AbilityProvider.tsx
+++ b/app/components/ability/AbilityProvider.tsx
@@ -41,7 +41,7 @@ export function AbilityProvider({ children }: AbilityProviderProps) {
     };
 
     fetchAbility();
-  }, [user?.id]);
+  }, [user]);
 
   const ability = useMemo(() => createPrismaAbility(rules), [rules]);
 

--- a/app/lib/casl/user-ability.ts
+++ b/app/lib/casl/user-ability.ts
@@ -8,7 +8,11 @@ import type { PrismaResources } from './prisma-helpers';
 import { getUserPermissions } from '~/lib/services/permissionService';
 import { logger } from '~/utils/logger';
 
-const ABILITY_CACHE: Record<string, AppAbility> = {};
+declare global {
+  var _abilityCache: Record<string, AppAbility> | undefined;
+}
+
+const ABILITY_CACHE = globalThis._abilityCache || (globalThis._abilityCache = {});
 
 type PrismaSubjects = Subjects<{
   Environment: Partial<Environment>;

--- a/app/lib/services/permissionService.ts
+++ b/app/lib/services/permissionService.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { PermissionAction, PermissionResource } from '@prisma/client';
 import type { Permission } from '@prisma/client';
+import { logger } from '~/utils/logger';
 
 export const PERMISSION_LEVELS = ['viewer', 'manage'] as const;
 
@@ -26,6 +27,8 @@ export function getPermissionLevelDetails(level: PermissionLevel): PermissionDet
 }
 
 export async function getUserPermissions(userId: string): Promise<Permission[]> {
+  logger.debug(`Fetching permissions for user ID: ${userId}`);
+
   const userWithRoles = await prisma.user.findUnique({
     where: { id: userId },
     include: {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@casl/ability": "^6.7.3",
     "@casl/prisma": "^1.5.1",
+    "@casl/react": "^5.0.0",
     "@clack/prompts": "^0.11.0",
     "@codemirror/autocomplete": "^6.18.3",
     "@codemirror/commands": "^6.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@casl/prisma':
         specifier: ^1.5.1
         version: 1.5.2(@casl/ability@6.7.3)(@prisma/client@6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2))
+      '@casl/react':
+        specifier: ^5.0.0
+        version: 5.0.0(@casl/ability@6.7.3)(react@18.3.1)
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1561,6 +1564,12 @@ packages:
     peerDependencies:
       '@casl/ability': ^5.3.0 || ^6.0.0
       '@prisma/client': ^2.14.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@casl/react@5.0.0':
+    resolution: {integrity: sha512-jiwr6uOBnQA7h0gs+RJIbFVF24Dw6JLiUPL4pfU0OEjWSJFCcYBz6RPU21XNciWL6xwFDOds81cHosuElxfdmw==}
+    peerDependencies:
+      '@casl/ability': ^4.0.0 || ^5.1.0 || ^6.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -12615,6 +12624,11 @@ snapshots:
       '@prisma/client': 6.13.0(prisma@6.13.0(typescript@5.9.2))(typescript@5.9.2)
       '@ucast/core': 1.10.2
       '@ucast/js': 3.0.4
+
+  '@casl/react@5.0.0(@casl/ability@6.7.3)(react@18.3.1)':
+    dependencies:
+      '@casl/ability': 6.7.3
+      react: 18.3.1
 
   '@clack/core@0.5.0':
     dependencies:

--- a/prisma/migrations/20250904195733_remove_deprecated_role/migration.sql
+++ b/prisma/migrations/20250904195733_remove_deprecated_role/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `role` on the `user` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."user" DROP COLUMN "role";
+
+-- DropEnum
+DROP TYPE "public"."DeprecatedRole";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,11 +222,6 @@ model Role {
   @@map("role")
 }
 
-enum DeprecatedRole {
-  ADMIN
-  MEMBER
-}
-
 model User {
   id                   String                @id @default(uuid())
   name                 String
@@ -239,7 +234,6 @@ model User {
   accounts             Account[]
   conversations        Conversation[]
   roles                UserRole[]
-  role                 DeprecatedRole        @default(MEMBER)
   dataSources          DataSource[]
   websites             Website[]
   environmentVariables EnvironmentVariable[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,5 @@
 import type { Account, Role, User } from '@prisma/client';
-import { DeprecatedRole, PermissionAction, PermissionResource, PrismaClient } from '@prisma/client';
+import { PermissionAction, PermissionResource, PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -32,7 +32,6 @@ async function seedInitialUser(): Promise<User> {
         email: 'anonymous@anonymous.com',
         name: 'Anonymous',
         emailVerified: false,
-        role: DeprecatedRole.ADMIN,
         isAnonymous: true,
         createdAt: new Date(),
         updatedAt: new Date(),


### PR DESCRIPTION
This PR removes DeprecatedRole and its references. DeprecatedRole was still used for frontend conditionals of the Admin tabs. This has been refactored to now use casl/react and the role permissions, removing the need to the old role. 

This PR also includes a fix to the ABILITY_CACHE for hot module development, and fixes to the role updates from the Members tab.

An example can now be seen with the <Can> to handle front end conditionals based on the users permissions.