### PR TITLE
Remove Roles Tab from Control Panel

### DIFF
--- a/app/components/@settings/core/ControlPanel.tsx
+++ b/app/components/@settings/core/ControlPanel.tsx
@@ -22,7 +22,6 @@ import GitHubTab from '~/components/@settings/tabs/connections/GitHubTab';
 import { Can } from '@casl/react';
 import { AbilityContext } from '~/components/ability/AbilityProvider';
 import MembersTab from '~/components/@settings/tabs/users/UsersTab';
-import RolesTab from '~/components/@settings/tabs/roles/RolesTab';
 import EnvironmentsTab from '~/components/@settings/tabs/environments';
 import SecretsManagerTab from '~/components/@settings/tabs/secrets-manager';
 
@@ -176,8 +175,6 @@ export const ControlPanel = () => {
         return <GitHubTab />;
       case 'members':
         return <MembersTab />;
-      case 'roles':
-        return <RolesTab />;
       default:
         return null;
     }

--- a/app/components/@settings/core/constants.ts
+++ b/app/components/@settings/core/constants.ts
@@ -1,12 +1,11 @@
 import type { TabType, TabVisibilityConfig } from './types';
-import { Database, GitBranch, type LucideIcon, Rocket, Users, Server, ShieldUser, Lock } from 'lucide-react';
+import { Database, GitBranch, type LucideIcon, Rocket, Users, Server, Lock } from 'lucide-react';
 
 export const TAB_ICONS: Record<TabType, string | LucideIcon> = {
   data: Database,
   github: GitBranch,
   'deployed-apps': Rocket,
   members: Users,
-  roles: ShieldUser,
   environments: Server,
   'secrets-manager': Lock,
 };
@@ -16,7 +15,6 @@ export const TAB_LABELS: Record<TabType, string> = {
   github: 'GitHub',
   'deployed-apps': 'Deployed Apps',
   members: 'Members',
-  roles: 'Roles',
   environments: 'Environments',
   'secrets-manager': 'Secrets Manager',
 };
@@ -26,7 +24,6 @@ export const TAB_DESCRIPTIONS: Record<TabType, string> = {
   github: 'Manage GitHub connection and repository settings',
   'deployed-apps': 'View and manage your deployed applications',
   members: 'Manage your members',
-  roles: 'Manage roles and permissions for users',
   environments: 'Manage your environments',
   'secrets-manager': 'Manage environment variables and secrets',
 };
@@ -39,5 +36,4 @@ export const DEFAULT_TAB_CONFIG: TabVisibilityConfig[] = [
   { id: 'deployed-apps', visible: true, window: 'user', order: 4 },
 
   { id: 'members', visible: true, window: 'admin', order: 1 },
-  { id: 'roles', visible: true, window: 'admin', order: 2 },
 ];

--- a/app/components/@settings/core/types.ts
+++ b/app/components/@settings/core/types.ts
@@ -1,4 +1,4 @@
-export type TabType = 'data' | 'github' | 'deployed-apps' | 'members' | 'roles' | 'environments' | 'secrets-manager';
+export type TabType = 'data' | 'github' | 'deployed-apps' | 'members' | 'environments' | 'secrets-manager';
 
 export type WindowType = 'user' | 'admin';
 
@@ -29,7 +29,6 @@ export const TAB_LABELS: Record<TabType, string> = {
   github: 'GitHub',
   'deployed-apps': 'Deployed Apps',
   members: 'Members',
-  roles: 'Roles',
   environments: 'Environments',
   'secrets-manager': 'Secrets Manager',
 };


### PR DESCRIPTION
This PR removes the roles tab from the control panel. This will come back with the introduction of custom roles in a later edition.