### PR TITLE
Add RBAC checks to datasource endpoints

### DIFF
--- a/app/api/data-sources/[id]/properties/route.ts
+++ b/app/api/data-sources/[id]/properties/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requireUserId } from '~/auth/session';
+import { PermissionAction, PermissionResource } from '@prisma/client';
+import { subject } from '@casl/ability';
+import { requireUserAbility } from '~/auth/session';
 import { getDataSourceProperties, getDataSourceType } from '~/lib/services/datasourceService';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const userId = await requireUserId(request);
+  const { userAbility } = await requireUserAbility(request);
 
   const { id } = await params;
   const { searchParams } = new URL(request.url);
@@ -14,13 +16,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ success: false, error: 'Environment ID is required' }, { status: 400 });
   }
 
+  if (
+    userAbility.cannot(PermissionAction.read, subject(PermissionResource.DataSource, { id })) &&
+    userAbility.cannot(PermissionAction.read, subject(PermissionResource.Environment, { id: environmentId }))
+  ) {
+    throw new Response('Forbidden', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+  }
+
   const dataSourceType = await getDataSourceType(id);
 
   if (!dataSourceType) {
     return NextResponse.json({ success: false, error: 'Data source type not found' }, { status: 404 });
   }
 
-  const dataSourceProperties = await getDataSourceProperties(userId, id, environmentId);
+  const dataSourceProperties = await getDataSourceProperties(id, environmentId);
 
   if (!dataSourceProperties) {
     return NextResponse.json({ success: false, error: 'Data source properties not found' }, { status: 404 });

--- a/app/api/data-sources/[id]/route.ts
+++ b/app/api/data-sources/[id]/route.ts
@@ -5,12 +5,13 @@ import {
   getEnvironmentDataSource,
   updateDataSource,
 } from '~/lib/services/datasourceService';
-import { requireUserId } from '~/auth/session';
-import { DataSourceType } from '@prisma/client';
+import { subject } from '@casl/ability';
+import { requireUserAbility } from '~/auth/session';
+import { DataSourceType, PermissionAction, PermissionResource } from '@prisma/client';
 import type { DataSourceProperty } from '@liblab/data-access/utils/types';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const userId = await requireUserId(request);
+  const { userAbility, userId } = await requireUserAbility(request);
 
   const { id } = await params;
   const { searchParams } = new URL(request.url);
@@ -20,10 +21,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ success: false, error: 'Environment ID is required' }, { status: 400 });
   }
 
-  const environmentDataSource = await getEnvironmentDataSource(id, userId, environmentId);
+  const environmentDataSource = await getEnvironmentDataSource(id, environmentId);
 
   if (!environmentDataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
+  }
+
+  if (
+    userAbility.cannot(
+      PermissionAction.read,
+      subject(PermissionResource.DataSource, environmentDataSource.dataSource),
+    ) &&
+    userAbility.cannot(
+      PermissionAction.read,
+      subject(PermissionResource.Environment, { id: environmentDataSource.environmentId }),
+    )
+  ) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
   const conversationCount = await getConversationCount(id, userId);
@@ -32,7 +46,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const userId = await requireUserId(request);
+  const { userAbility, userId } = await requireUserAbility(request);
 
   const { id } = await params;
   const { searchParams } = new URL(request.url);
@@ -42,10 +56,23 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ success: false, error: 'Environment ID is required' }, { status: 400 });
   }
 
-  const environmentDataSource = await getEnvironmentDataSource(id, userId, environmentId);
+  const environmentDataSource = await getEnvironmentDataSource(id, environmentId);
 
   if (!environmentDataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
+  }
+
+  if (
+    userAbility.cannot(
+      PermissionAction.update,
+      subject(PermissionResource.DataSource, environmentDataSource.dataSource),
+    ) &&
+    userAbility.cannot(
+      PermissionAction.update,
+      subject(PermissionResource.Environment, { id: environmentDataSource.environmentId }),
+    )
+  ) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
   const formData = await request.formData();
@@ -73,7 +100,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const userId = await requireUserId(request);
+  const { userAbility } = await requireUserAbility(request);
   const { id } = await params;
   const { searchParams } = new URL(request.url);
   const environmentId = searchParams.get('environmentId');
@@ -82,13 +109,26 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     return NextResponse.json({ success: false, error: 'Environment ID is required' }, { status: 400 });
   }
 
-  const environmentDataSource = await getEnvironmentDataSource(id, userId, environmentId);
+  const environmentDataSource = await getEnvironmentDataSource(id, environmentId);
 
   if (!environmentDataSource) {
     return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
   }
 
-  await deleteDataSource(id, userId);
+  if (
+    userAbility.cannot(
+      PermissionAction.delete,
+      subject(PermissionResource.DataSource, environmentDataSource.dataSource),
+    ) &&
+    userAbility.cannot(
+      PermissionAction.delete,
+      subject(PermissionResource.Environment, { id: environmentDataSource.environmentId }),
+    )
+  ) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  await deleteDataSource(id);
 
   return NextResponse.json({ success: true });
 }

--- a/app/api/data-sources/route.ts
+++ b/app/api/data-sources/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { subject } from '@casl/ability';
 import { requireUserAbility } from '~/auth/session';
 import { DataSourceType, PermissionAction, PermissionResource } from '@prisma/client';
 import { createDataSource, getEnvironmentDataSources } from '~/lib/services/datasourceService';
@@ -18,10 +19,6 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const { userId, userAbility } = await requireUserAbility(request);
 
-  if (!userAbility.can(PermissionAction.create, PermissionResource.DataSource)) {
-    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
-  }
-
   const formData = await request.formData();
   const name = formData.get('name') as string;
   const type = formData.get('type') as DataSourceType;
@@ -29,6 +26,13 @@ export async function POST(request: NextRequest) {
 
   if (!environmentId) {
     return NextResponse.json({ success: false, error: 'Environment ID is required' }, { status: 400 });
+  }
+
+  if (
+    userAbility.cannot(PermissionAction.create, PermissionResource.DataSource) &&
+    userAbility.cannot(PermissionAction.create, subject(PermissionResource.Environment, { id: environmentId }))
+  ) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
   const propertiesJson = formData.get('properties') as string;

--- a/app/api/suggestions/route.ts
+++ b/app/api/suggestions/route.ts
@@ -37,10 +37,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'Data source not found' }, { status: 404 });
     }
 
-    console.log(environmentDataSource);
-
-    console.log(JSON.stringify(userAbility));
-
     if (
       userAbility.cannot(
         PermissionAction.read,

--- a/app/lib/services/conversationService.ts
+++ b/app/lib/services/conversationService.ts
@@ -10,19 +10,15 @@ export const conversationService = {
     });
   },
 
-  async getConversationEnvironmentDataSource(conversationId: string, userId: string) {
+  async getConversationEnvironmentDataSource(conversationId: string) {
     const conversation = await prisma.conversation.findUniqueOrThrow({
       where: { id: conversationId },
     });
 
-    const environmentDataSource = await getEnvironmentDataSource(
-      conversation.dataSourceId,
-      userId,
-      conversation.environmentId,
-    );
+    const environmentDataSource = await getEnvironmentDataSource(conversation.dataSourceId, conversation.environmentId);
 
     if (!environmentDataSource) {
-      throw new Error('Environment data source not found or access denied');
+      throw new Error('Environment data source not found');
     }
 
     return environmentDataSource;

--- a/app/lib/services/datasourceService.ts
+++ b/app/lib/services/datasourceService.ts
@@ -76,7 +76,6 @@ export type ComplexEnvironmentDataSource = EnvironmentDataSource & { dataSource:
 
 export async function getEnvironmentDataSource(
   dataSourceId: string,
-  userId: string,
   environmentId: string,
 ): Promise<ComplexEnvironmentDataSource | null> {
   const environmentDataSource = await prisma.environmentDataSource.findUnique({
@@ -98,9 +97,7 @@ export async function getEnvironmentDataSource(
     },
   });
 
-  // TODO: @skos Update specific permissions
-  // Verify user has access to this data source
-  if (!environmentDataSource || environmentDataSource.dataSource.createdById !== userId) {
+  if (!environmentDataSource) {
     return null;
   }
 
@@ -193,7 +190,7 @@ export async function getDataSourceConnectionUrl(
   dataSourceId: string,
   environmentId: string,
 ): Promise<string | null> {
-  const dataSourceProperties = await getDataSourceProperties(userId, dataSourceId, environmentId);
+  const dataSourceProperties = await getDataSourceProperties(dataSourceId, environmentId);
 
   return dataSourceProperties?.find((prop) => prop.type === SharedDataSourcePropertyType.CONNECTION_URL)?.value || null;
 }
@@ -285,10 +282,10 @@ export async function updateDataSource(data: {
   });
 }
 
-export async function deleteDataSource(id: string, userId: string) {
+export async function deleteDataSource(id: string) {
   prisma.dataSourceProperty.deleteMany({ where: { dataSourceId: id } });
 
-  return prisma.dataSource.delete({ where: { id, createdById: userId } });
+  return prisma.dataSource.delete({ where: { id } });
 }
 
 export async function getDataSourceType(dataSourceId: string) {
@@ -301,7 +298,6 @@ export async function getDataSourceType(dataSourceId: string) {
 }
 
 export async function getDataSourceProperties(
-  userId: string,
   dataSourceId: string,
   environmentId: string,
 ): Promise<SimpleDataSourceProperty[] | null> {
@@ -309,9 +305,6 @@ export async function getDataSourceProperties(
     where: {
       environmentId,
       dataSourceId,
-      dataSource: {
-        createdById: userId, // ownership check
-      },
     },
     include: {
       dataSourceProperties: {


### PR DESCRIPTION
This PR adds appropriate RBAC checks to datasource endpoints. It allows for permissions directly to the datasource or cascaded by the environment permissions.