### PR TITLE
add rback checks to environments and websites

### DIFF
--- a/app/api/environments/[id]/route.ts
+++ b/app/api/environments/[id]/route.ts
@@ -1,16 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { deleteEnvironment, getEnvironment, updateEnvironment } from '~/lib/services/environmentService';
+import { subject } from '@casl/ability';
 import { requireUserAbility } from '~/auth/session';
 import { PermissionAction, PermissionResource, Prisma } from '@prisma/client';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userAbility } = await requireUserAbility(request);
+  const { id } = await params;
 
-  if (!userAbility.can(PermissionAction.read, PermissionResource.Environment)) {
+  if (!userAbility.can(PermissionAction.read, subject(PermissionResource.Environment, { id }))) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
-
-  const { id } = await params;
 
   const environment = await getEnvironment(id);
 
@@ -23,12 +23,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userAbility } = await requireUserAbility(request);
+  const { id } = await params;
 
-  if (!userAbility.can(PermissionAction.update, PermissionResource.Environment)) {
+  if (!userAbility.can(PermissionAction.update, subject(PermissionResource.Environment, { id }))) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
-
-  const { id } = await params;
 
   const body = (await request.json()) as {
     name: string;
@@ -62,12 +61,11 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userAbility } = await requireUserAbility(request);
+  const { id } = await params;
 
-  if (!userAbility.can(PermissionAction.delete, PermissionResource.Environment)) {
+  if (!userAbility.can(PermissionAction.delete, subject(PermissionResource.Environment, { id }))) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
-
-  const { id } = await params;
 
   try {
     await deleteEnvironment(id);

--- a/app/api/environments/route.ts
+++ b/app/api/environments/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
-  const environments = await getEnvironments();
+  const environments = await getEnvironments(userAbility);
 
   return NextResponse.json({ success: true, environments });
 }

--- a/app/api/websites/[id]/route.ts
+++ b/app/api/websites/[id]/route.ts
@@ -35,12 +35,17 @@ async function deleteNetlifySite(siteId: string) {
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { userAbility } = await requireUserAbility(request);
-
     const { id } = await params;
 
     const website = await getWebsite(id);
 
-    if (userAbility.cannot(PermissionAction.read, subject(PermissionResource.Website, website!))) {
+    if (
+      userAbility.cannot(PermissionAction.read, subject(PermissionResource.Website, website)) &&
+      userAbility.cannot(
+        PermissionAction.read,
+        subject(PermissionResource.Environment, { id: website.environmentId ?? undefined }),
+      )
+    ) {
       return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
     }
 
@@ -72,7 +77,13 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     const website = await getWebsite(id);
 
-    if (userAbility.cannot(PermissionAction.update, subject(PermissionResource.Website, website!))) {
+    if (
+      userAbility.cannot(PermissionAction.update, subject(PermissionResource.Website, website)) &&
+      userAbility.cannot(
+        PermissionAction.update,
+        subject(PermissionResource.Environment, { id: website.environmentId ?? undefined }),
+      )
+    ) {
       return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
     }
 
@@ -95,7 +106,13 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
 
     const website = await getWebsite(id);
 
-    if (userAbility.cannot(PermissionAction.delete, subject(PermissionResource.Website, website!))) {
+    if (
+      userAbility.cannot(PermissionAction.delete, subject(PermissionResource.Website, website)) &&
+      userAbility.cannot(
+        PermissionAction.delete,
+        subject(PermissionResource.Environment, { id: website.environmentId ?? undefined }),
+      )
+    ) {
       return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
     }
 

--- a/app/lib/services/environmentService.ts
+++ b/app/lib/services/environmentService.ts
@@ -1,5 +1,8 @@
 import { prisma } from '~/lib/prisma';
-import type { Environment } from '@prisma/client';
+import { PermissionAction, PermissionResource } from '@prisma/client';
+import type { Environment, Prisma } from '@prisma/client';
+import { buildResourceWhereClause } from '@/lib/casl/prisma-helpers';
+import type { AppAbility } from '~/lib/casl/user-ability';
 
 export interface EnvironmentWithRelations extends Environment {
   dataSources: any[];
@@ -29,8 +32,15 @@ export async function getEnvironmentName(id: string): Promise<string | null> {
   return env?.name ?? null;
 }
 
-export async function getEnvironments(): Promise<EnvironmentWithRelations[]> {
+export async function getEnvironments(userAbility: AppAbility): Promise<EnvironmentWithRelations[]> {
+  const whereClause = buildResourceWhereClause(
+    userAbility,
+    PermissionAction.read,
+    PermissionResource.Environment,
+  ) as Prisma.EnvironmentWhereInput;
+
   const environments = await prisma.environment.findMany({
+    where: whereClause,
     include: {
       dataSources: {
         include: {


### PR DESCRIPTION
This PR adds appropriate RBAC checks to environment and website endpoints. It allows for permissions directly to the website or cascaded by the environment permissions.