### PR TITLE
Filter Role Selection in Admin Members view

### DIFF
--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -11,7 +11,22 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
-  const roles = await getRoles();
+  const { searchParams } = new URL(request.url);
+  const scopeParam = searchParams.get('scope');
+
+  // If a role scope is provided, validate it and override the default
+  // default undefined will fetch all roles
+  let scope: RoleScope | undefined = undefined;
+
+  if (scopeParam) {
+    if (Object.values(RoleScope).includes(scopeParam as RoleScope)) {
+      scope = scopeParam as RoleScope;
+    } else {
+      return NextResponse.json({ success: false, error: 'Invalid scope parameter' }, { status: 400 });
+    }
+  }
+
+  const roles = await getRoles({ scope });
 
   return NextResponse.json({ success: true, roles });
 }

--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
-  const { searchParams } = new URL(request.url);
+  const { searchParams } = request.nextUrl;
   const scopeParam = searchParams.get('scope');
 
   // If a role scope is provided, validate it and override the default

--- a/app/components/@settings/tabs/users/UsersTab.tsx
+++ b/app/components/@settings/tabs/users/UsersTab.tsx
@@ -138,7 +138,7 @@ export default function UsersTab() {
 
     const fetchRoles = async () => {
       try {
-        const response = await fetch('/api/roles');
+        const response = await fetch('/api/roles?scope=GENERAL');
         const data = (await response.json()) as { success: boolean; roles?: Role[] };
 
         if (data.success && data.roles) {

--- a/app/lib/services/roleService.ts
+++ b/app/lib/services/roleService.ts
@@ -20,8 +20,15 @@ export async function getRole(id: string): Promise<Role | null> {
   });
 }
 
-export async function getRoles(): Promise<Role[]> {
+interface GetRolesParams {
+  scope?: RoleScope;
+}
+
+export async function getRoles({ scope }: GetRolesParams): Promise<Role[]> {
   const roles = await prisma.role.findMany({
+    where: {
+      scope,
+    },
     include: {
       permissions: true,
       users: {

--- a/app/lib/services/roleService.ts
+++ b/app/lib/services/roleService.ts
@@ -24,7 +24,7 @@ interface GetRolesParams {
   scope?: RoleScope;
 }
 
-export async function getRoles({ scope }: GetRolesParams): Promise<Role[]> {
+export async function getRoles({ scope }: GetRolesParams = {}): Promise<Role[]> {
   const roles = await prisma.role.findMany({
     where: {
       scope,


### PR DESCRIPTION
This PR fixes a bug of seeing dynamic resource roles in the Admin Members role selection.

To fix /api/roles was parameterized to allow filtering to satisfy the frontend use case of only displaying General / Organizational Roles.

For Context:
https://linear.app/liblab/issue/ENG-1014/filter-role-selection-in-admin-members-view