### PR TITLE
Fix the memory leak in DataLoader

### DIFF
--- a/app/components/DataLoader.tsx
+++ b/app/components/DataLoader.tsx
@@ -70,11 +70,13 @@ export function DataLoader({ children, rootData }: DataLoaderProps) {
       setProviders(rootData.deploymentProviders);
     }
   }, [
-    rootData.pluginAccess,
-    rootData.dataSourceTypes,
-    rootData.environmentVariables,
-    rootData.environmentDeploymentMethods,
-    rootData.deploymentProviders,
+    JSON.stringify({
+      pluginAccess: rootData.pluginAccess,
+      dataSourceTypes: rootData.dataSourceTypes,
+      environmentVariables: rootData.environmentVariables,
+      environmentDeploymentMethods: rootData.environmentDeploymentMethods,
+      deploymentProviders: rootData.deploymentProviders,
+    }),
     setPluginAccess,
     setDataSourceTypes,
     setEnvironmentVariables,


### PR DESCRIPTION
## 📋 Pull Request Summary
DataLoader has a problem with the useEffect dependency array where we add objects, and it falls in an infinite loop, causing a memory leak.
A fix is to stringify the object, meaning it won't re-trigger the effect unless the object values changes.

### 🔗 Related Issues

<!-- Link to related issues using keywords: fixes #123, closes #456, relates to #789 -->

- Fixes #
- Relates to #

### 📝 Changes Made

<!-- Describe the changes in detail -->

-
-
-

### 🧪 Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

**Testing Details:**

<!-- Describe your testing approach -->

### 📚 Documentation

<!-- Check all that apply -->

- [ ] Code is self-documenting with clear variable/function names
- [ ] Added/updated JSDoc comments for public APIs
- [ ] Updated README.md if needed
- [ ] Updated other documentation files
- [ ] No documentation changes needed

### 🔄 Type of Change

<!-- Check the type of change -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

### 🚨 Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided
- [ ] Deprecation warnings added

**Breaking Change Details:**

<!-- Describe what breaks and how users should migrate -->

### 📸 Screenshots/Videos

<!-- Include screenshots or videos for UI changes -->

### 📋 Additional Notes

<!-- Any additional information for reviewers -->
