### PR TITLE
Fix broken logic while handling license access

### DIFF
--- a/app/lib/plugins/plugin-manager.ts
+++ b/app/lib/plugins/plugin-manager.ts
@@ -141,31 +141,22 @@ class PluginManager {
 
     // If license is free, only allow anonymous auth and configured providers
     if (!license || license !== 'premium') {
-      console.log('📋 Using FREE_PLUGIN_ACCESS with dynamic provider support');
-      return {
-        ...FREE_PLUGIN_ACCESS,
-        [PluginType.AUTH]: {
-          ...FREE_PLUGIN_ACCESS[PluginType.AUTH],
-          google: hasGoogleOAuth,
-          oidc: hasOIDCSSO,
-        },
-      };
-    }
-
-    // If license is premium but neither Google OAuth nor OIDC SSO is configured, fall back to free access
-    if (!hasGoogleOAuth && !hasOIDCSSO) {
-      console.warn(
-        'Premium license detected but neither Google OAuth nor OIDC SSO configured. Falling back to free access.',
-      );
-      console.log('📋 Falling back to FREE_PLUGIN_ACCESS');
-
+      console.log('📋 Using FREE_PLUGIN_ACCESS');
       return FREE_PLUGIN_ACCESS;
     }
 
     // Premium license with Google OAuth or OIDC SSO configured
     console.log('📋 Using PREMIUM_PLUGIN_ACCESS');
 
-    return PREMIUM_PLUGIN_ACCESS;
+    return {
+      ...PREMIUM_PLUGIN_ACCESS,
+      [PluginType.AUTH]: {
+        ...PREMIUM_PLUGIN_ACCESS[PluginType.AUTH],
+        anonymous: !(hasGoogleOAuth || hasOIDCSSO),
+        google: hasGoogleOAuth,
+        oidc: hasOIDCSSO,
+      },
+    };
   }
 }
 

--- a/app/lib/plugins/plugin-manager.ts
+++ b/app/lib/plugins/plugin-manager.ts
@@ -123,6 +123,11 @@ class PluginManager {
   // Mock API call until we implement the backend
   private async _fetchPluginAccess(): Promise<PluginAccessMap> {
     const license = env.server.LICENSE_KEY;
+
+    if (!license || license !== 'premium') {
+      return FREE_PLUGIN_ACCESS;
+    }
+
     const {
       GOOGLE_CLIENT_ID,
       GOOGLE_CLIENT_SECRET,
@@ -138,15 +143,6 @@ class PluginManager {
 
     // Check if OIDC SSO is configured
     const hasOIDCSSO = !!(OIDC_ISSUER && OIDC_CLIENT_ID && OIDC_CLIENT_SECRET && OIDC_DOMAIN && OIDC_PROVIDER_ID);
-
-    // If license is free, only allow anonymous auth and configured providers
-    if (!license || license !== 'premium') {
-      console.log('📋 Using FREE_PLUGIN_ACCESS');
-      return FREE_PLUGIN_ACCESS;
-    }
-
-    // Premium license with Google OAuth or OIDC SSO configured
-    console.log('📋 Using PREMIUM_PLUGIN_ACCESS');
 
     return {
       ...PREMIUM_PLUGIN_ACCESS,


### PR DESCRIPTION
This pull request updates the plugin access logic in the `PluginManager` class to simplify and clarify how plugin access is determined based on the license type and authentication provider configuration. The main changes focus on ensuring that premium features are only enabled with a valid premium license, and on streamlining the logic for determining available authentication providers.

Plugin access logic improvements:

* Simplified the license check in `_fetchPluginAccess` by immediately returning `FREE_PLUGIN_ACCESS` if the license is missing or not set to `'premium'`, reducing unnecessary branching and clarifying the flow.
* Refactored the logic for determining available authentication providers: now, when a premium license is present, the returned access map is always based on `PREMIUM_PLUGIN_ACCESS`, with dynamic enabling of `google` and `oidc` providers depending on their configuration, and the `anonymous` provider is only enabled if neither is configured.
* Removed redundant and potentially confusing fallback logic that previously reverted to free access if no premium authentication providers were configured, ensuring premium users always get premium access options.