### PR TITLE
Feature/eng 1089/iconsax license attribution

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,40 +2,36 @@
 
 This software contains components from the following third-party libraries:
 
-**@ai-sdk/amazon-bedrock**
+**@ai-sdk/amazon-bedrock** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/anthropic**
+**@ai-sdk/anthropic** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/cohere**
+**@ai-sdk/cohere** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/deepseek**
+**@ai-sdk/deepseek** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/google**
+**@ai-sdk/google** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/mistral**
+**@ai-sdk/mistral** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/openai**
+**@ai-sdk/openai** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@ai-sdk/react**
+**@ai-sdk/react** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**@openrouter/ai-sdk-provider**
-No copyright found
-
-**ai**
+**@openrouter/ai-sdk-provider** (Apache License)
+**ai** (Apache License)
 Copyright 2023 Vercel, Inc.
 
-**class-variance-authority**
-No copyright found
-
-**diff:**
+**class-variance-authority** (Apache License)
+**diff:** (BSD License)
 BSD 3-Clause License
 
 Copyright (c) 2009-2015, Kevin Decker <kpdecker@gmail.com>
@@ -66,7 +62,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-**dotenv:**
+**dotenv:** (BSD License)
 Copyright (c) 2015, Scott Motte
 All rights reserved.
 
@@ -91,22 +87,12 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-**google-auth-library**
-No copyright found
-
-**googleapis**
-No copyright found
-
-**mongodb-query-parser**
-Copyright {yyyy} {name of copyright owner}
-
-**mongodb**
-No copyright found
-
-**ollama-ai-provider**
-No copyright found
-
-**react-beautiful-dnd**
+**google-auth-library** (Apache License)
+**googleapis** (Apache License)
+**mongodb-query-parser** (Apache License)
+**mongodb** (Apache License)
+**ollama-ai-provider** (Apache License)
+**react-beautiful-dnd** (Apache License)
 Copyright 2019 Atlassian Pty Ltd
 
 This project utilizes icons provided by Iconsax https://iconsax.io (Propietary Free Licensed.).

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -91,6 +91,15 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+**google-auth-library**
+No copyright found
+
+**googleapis**
+No copyright found
+
+**mongodb-query-parser**
+Copyright {yyyy} {name of copyright owner}
+
 **mongodb**
 No copyright found
 
@@ -99,3 +108,5 @@ No copyright found
 
 **react-beautiful-dnd**
 Copyright 2019 Atlassian Pty Ltd
+
+This project utilizes icons provided by Iconsax https://iconsax.io (Propietary Free Licensed.).

--- a/scripts/license-builder.ts
+++ b/scripts/license-builder.ts
@@ -55,11 +55,16 @@ checker.init(options, (err: Error, packages: ModuleInfos) => {
       const licensesStr = Array.isArray(info.licenses) ? info.licenses.join(', ') : info.licenses || 'Unknown';
 
       if (licensesStr.startsWith('BSD')) {
-        console.log(`**${trimmedPkg}:**`);
+        console.log(`**${trimmedPkg}:** (BSD License)`);
         console.log(`${info.licenseText}\n`);
       } else if (licensesStr.startsWith('Apache')) {
-        // Add other licenses like || licensesStr.startsWith('MIT') if needed
-        console.log(`**${trimmedPkg}**\n${copyrightLine || 'No copyright found'}\n`);
+        console.log(`**${trimmedPkg}** (Apache License)`);
+
+        // Remove copyright line if it was just part of the template (it would have 'yyyy' in the template)
+        if (copyrightLine && copyrightLine.search('yyyy') === -1) {
+          // Add other licenses like || licensesStr.startsWith('MIT') if needed
+          console.log(`${copyrightLine || '\n'}\n`);
+        }
       }
     }
   });

--- a/scripts/license-builder.ts
+++ b/scripts/license-builder.ts
@@ -72,5 +72,5 @@ checker.init(options, (err: Error, packages: ModuleInfos) => {
   // Add on notices
 
   // Iconsax icons (free license unless commercial use)
-  console.log('\nThis project utilizes icons provided by Iconsax https://iconsax.io (Propietary Free Licensed.).\n');
+  console.log('\nThis project utilizes icons provided by Iconsax https://iconsax.io (Proprietary Free License).\n');
 });

--- a/scripts/license-builder.ts
+++ b/scripts/license-builder.ts
@@ -63,4 +63,9 @@ checker.init(options, (err: Error, packages: ModuleInfos) => {
       }
     }
   });
+
+  // Add on notices
+
+  // Iconsax icons (free license unless commercial use)
+  console.log('\nThis project utilizes icons provided by Iconsax https://iconsax.io (Propietary Free Licensed.).\n');
 });


### PR DESCRIPTION
## 📋 Pull Request Summary
This PR does not impact the builder app.  It's only a script to auto-generate the NOTICE.md file.

The iconsax package that we use for icons requires us to specifically attribute the package in our NOTICE.md file even though it is an MIT license (which usually don't require attribution).  Because of this special case, it needed to be specifically added to the script that auto-creates our NOTICE file.

While in there, I also cleaned up the case where the author cut and pasted the whole Apache template into their LICENSE file without filling out the copyright details.  Rather than printing out "Copyright yyyy, author", we removed this.

